### PR TITLE
Non-workspace Preview

### DIFF
--- a/media/inject_script.html
+++ b/media/inject_script.html
@@ -33,11 +33,16 @@
 	
 
 	document.addEventListener('DOMContentLoaded', function (e) {
-
+		commandPayload = {
+			"pathname": window.location.pathname,
+			"fullPath": window.location,
+			"title": document.title
+		}
 		window.parent.postMessage(
-		{ command: 'update-path', text: `{"pathname":"${window.location.pathname}","fullPath":"${window.location}","title":"${document.title}"}` },
+		{ command: 'update-path', text: JSON.stringify(commandPayload) },
 			'*'
 		);
+		// console.log(JSON.stringify(commandPayload))
 
 		var l = document.getElementsByTagName('a');
 		for (var i = 0; i < l.length; i++) {

--- a/media/inject_script.html
+++ b/media/inject_script.html
@@ -22,24 +22,31 @@
 			if (this.event.data == 'refresh') {
 				window.location.reload();
 			} else if (this.event.data == 'setup-parent-listener') {
+				commandPayload = {
+					pathname: window.location.pathname,
+					fullPath: window.location,
+					title: document.title,
+				};
 				window.parent.postMessage(
-				{ command: 'update-path', text: `{"pathname":"${window.location.pathname}","fullPath":"${window.location}","title":"${document.title}"}` },
+					{
+						command: 'update-path',
+						text: JSON.stringify(commandPayload),
+					},
 					'*'
 				);
 			}
 		},
 		false
 	);
-	
 
 	document.addEventListener('DOMContentLoaded', function (e) {
 		commandPayload = {
-			"pathname": window.location.pathname,
-			"fullPath": window.location,
-			"title": document.title
-		}
+			pathname: window.location.pathname,
+			fullPath: window.location,
+			title: document.title,
+		};
 		window.parent.postMessage(
-		{ command: 'update-path', text: JSON.stringify(commandPayload) },
+			{ command: 'update-path', text: JSON.stringify(commandPayload) },
 			'*'
 		);
 		// console.log(JSON.stringify(commandPayload))

--- a/media/main.js
+++ b/media/main.js
@@ -97,12 +97,14 @@
 					command: 'update-path',
 					text: message.text,
 				});
-				document.getElementById('url-input').value = msgJSON.fullPath;
+				// console.log(msgJSON);
+				document.getElementById('url-input').value = msgJSON.fullPath.href;
 				vscode.setState({currentAddress: msgJSON.pathname});
 				break;
 			}
 			case 'set-url': {
 				msgJSON = JSON.parse(message.text);
+				// console.log(msgJSON);
 				document.getElementById('url-input').value = msgJSON.fullPath;
 				vscode.setState({currentAddress: msgJSON.pathname});
 				break;

--- a/media/main.js
+++ b/media/main.js
@@ -5,7 +5,7 @@
 (function () {
 	const vscode = acquireVsCodeApi();
 
-	vscode.setState({currentAddress: window.location.pathname});
+	vscode.setState({ currentAddress: window.location.pathname });
 	const connection = new WebSocket(WS_URL);
 
 	connection.onerror = (error) => {
@@ -57,18 +57,20 @@
 		});
 	};
 
-	document.getElementById('url-input').addEventListener("keyup", function(event) {
-		// Number 13 is the "Enter" key on the keyboard
-		if (event.keyCode === 13) {
-			// Cancel the default action, if needed
-			event.preventDefault();
-			linkTarget = document.getElementById('url-input').value;
-			vscode.postMessage({
-				command: 'go-to-file',
-				text: linkTarget,
-			});
-		}
-	});
+	document
+		.getElementById('url-input')
+		.addEventListener('keyup', function (event) {
+			// Number 13 is the "Enter" key on the keyboard
+			if (event.keyCode === 13) {
+				// Cancel the default action, if needed
+				event.preventDefault();
+				linkTarget = document.getElementById('url-input').value;
+				vscode.postMessage({
+					command: 'go-to-file',
+					text: linkTarget,
+				});
+			}
+		});
 	window.addEventListener('message', (event) => {
 		const message = event.data; // The json data that the extension sent
 		switch (message.command) {
@@ -99,14 +101,13 @@
 				});
 				// console.log(msgJSON);
 				document.getElementById('url-input').value = msgJSON.fullPath.href;
-				vscode.setState({currentAddress: msgJSON.pathname});
+				vscode.setState({ currentAddress: msgJSON.pathname });
 				break;
 			}
 			case 'set-url': {
 				msgJSON = JSON.parse(message.text);
-				// console.log(msgJSON);
 				document.getElementById('url-input').value = msgJSON.fullPath;
-				vscode.setState({currentAddress: msgJSON.pathname});
+				vscode.setState({ currentAddress: msgJSON.pathname });
 				break;
 			}
 			case 'open-external-link': {
@@ -118,14 +119,17 @@
 				break;
 			}
 			case 'perform-url-check': {
-				connection.send(`{"command":"urlCheck","url":"${message.text}"}`);
+				sendData = {
+					command: 'urlCheck',
+					url: message.text,
+				};
+				connection.send(JSON.stringify(sendData));
 				break;
 			}
 		}
 	});
-	
-	document
-	.getElementById('hostedContent')
-	.contentWindow.postMessage('setup-parent-listener', '*');
 
+	document
+		.getElementById('hostedContent')
+		.contentWindow.postMessage('setup-parent-listener', '*');
 })();

--- a/package.json
+++ b/package.json
@@ -17,7 +17,14 @@
 	],
 	"activationEvents": [
 		"workspaceContains:**/*.html",
-		"onWebviewPanel:browserPreview"
+		"onWebviewPanel:browserPreview",
+		"onCommand:LiveServer.start.preview.atIndex",
+		"onCommand:LiveServer.start.preview.atFile",
+		"onCommand:LiveServer.start.externalPreview.atIndex",
+		"onCommand:LiveServer.start.internalPreview.atIndex",
+		"onCommand:LiveServer.start.externalPreview.atFile",
+		"onCommand:LiveServer.start.internalPreview.atFile",
+		"onCommand:LiveServer.end"
 	],
 	"main": "./out/extension.js",
 	"contributes": {

--- a/package.json
+++ b/package.json
@@ -141,10 +141,10 @@
 					"default": true,
 					"description": "Upon running `Live Server: Show Preview in External Browser`, whether the auto-general terminal has logging."
 				},
-				"LiveServer.notifyOnOpenNonWorkspaceFile": {
+				"LiveServer.notifyOnOpenLooseFile": {
 					"type": "boolean",
 					"default": true,
-					"description": "Whether to notify the user when opening a preview for a file that is not part of the currently opened workspace."
+					"description": "Whether to notify the user when opening a preview for a file that is not part of the currently opened workspace (or the workspace where the server is hosted)."
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -140,6 +140,11 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Upon running `Live Server: Show Preview in External Browser`, whether the auto-general terminal has logging."
+				},
+				"LiveServer.notifyOnOpenNonWorkspaceFile": {
+					"type": "boolean",
+					"default": true,
+					"description": "Whether to notify the user when opening a preview for a file that is not part of the currently opened workspace."
 				}
 			}
 		},

--- a/src/editorPreview/browserPreview.ts
+++ b/src/editorPreview/browserPreview.ts
@@ -1,7 +1,8 @@
 import * as vscode from 'vscode';
 import { HOST, INIT_PANEL_TITLE, OPEN_EXTERNALLY } from '../utils/constants';
 import { Disposable } from '../utils/dispose';
-import { GetFileName, isFileInjectable, IsLooseFilePath } from '../utils/utils';
+import { isFileInjectable } from '../utils/utils';
+import { PathUtil } from '../utils/pathUtil';
 import { PageHistory, NavEditCommands } from './pageHistoryTracker';
 
 export class BrowserPreview extends Disposable {
@@ -356,8 +357,8 @@ export class BrowserPreview extends Disposable {
 	private setPanelTitle(title = '', pathname = 'Preview'): void {
 		if (title == '') {
 			if (pathname.length > 0 && pathname[0] == '/') {
-				if (IsLooseFilePath(pathname)) {
-					this._panel.title = GetFileName(pathname);
+				if (PathUtil.IsLooseFilePath(pathname)) {
+					this._panel.title = PathUtil.GetFileName(pathname);
 				} else {
 					this._panel.title = pathname.substr(1);
 				}

--- a/src/editorPreview/browserPreview.ts
+++ b/src/editorPreview/browserPreview.ts
@@ -100,7 +100,10 @@ export class BrowserPreview extends Disposable {
 					case 'add-history': {
 						this._panel.webview.postMessage({
 							command: 'set-url',
-							text: JSON.stringify({ fullPath: this.constructAddress(message.text), pathname: message.text }),
+							text: JSON.stringify({
+								fullPath: this.constructAddress(message.text),
+								pathname: message.text,
+							}),
 						});
 						// called from main.js in the case where the target is non-injectable
 						this.handleNewPageLoad(message.text);

--- a/src/editorPreview/browserPreview.ts
+++ b/src/editorPreview/browserPreview.ts
@@ -119,7 +119,6 @@ export class BrowserPreview extends Disposable {
 
 	dispose() {
 		this._onDisposeEmitter.fire();
-		this._onDisposeEmitter.dispose();
 		super.dispose();
 	}
 
@@ -355,7 +354,7 @@ export class BrowserPreview extends Disposable {
 		if (title == '') {
 			if (pathname.length > 0 && pathname[0] == '/') {
 				if (IsLooseFilePath(pathname)) {
-					this._panel.title = `Loose File - ${GetFileName(pathname)}`;
+					this._panel.title = GetFileName(pathname);
 				} else {
 					this._panel.title = pathname.substr(1);
 				}

--- a/src/editorPreview/browserPreview.ts
+++ b/src/editorPreview/browserPreview.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { HOST, INIT_PANEL_TITLE, OPEN_EXTERNALLY } from '../utils/constants';
 import { Disposable } from '../utils/dispose';
-import { isFileInjectable } from '../utils/utils';
+import { GetFileName, isFileInjectable, IsLooseFilePath } from '../utils/utils';
 import { PageHistory, NavEditCommands } from './pageHistoryTracker';
 
 export class BrowserPreview extends Disposable {
@@ -354,7 +354,11 @@ export class BrowserPreview extends Disposable {
 	private setPanelTitle(title = '', pathname = 'Preview'): void {
 		if (title == '') {
 			if (pathname.length > 0 && pathname[0] == '/') {
-				this._panel.title = pathname.substr(1);
+				if (IsLooseFilePath(pathname)) {
+					this._panel.title = `Loose File - ${GetFileName(pathname)}`;
+				} else {
+					this._panel.title = pathname.substr(1);
+				}
 			} else {
 				this._panel.title = pathname;
 			}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,7 +42,11 @@ export function activate(context: vscode.ExtensionContext) {
 		)
 	);
 
-	const openPreview = (internal: boolean, file: string, isRelative: boolean) => {
+	const openPreview = (
+		internal: boolean,
+		file: string,
+		isRelative: boolean
+	) => {
 		if (internal) {
 			manager.createOrShowPreview(undefined, file, isRelative);
 		} else {
@@ -74,7 +78,9 @@ export function activate(context: vscode.ExtensionContext) {
 			}
 		}
 
-		vscode.window.showErrorMessage("This file is not a part of the workspace where the server has started. Cannot preview.");
+		vscode.window.showErrorMessage(
+			'This file is not a part of the workspace where the server has started. Cannot preview.'
+		);
 		return;
 	};
 
@@ -117,7 +123,7 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		vscode.commands.registerCommand(`${SETTINGS_SECTION_ID}.end`, () => {
 			if (!manager.closeServer()) {
-				vscode.window.showErrorMessage("Server already off.");
+				vscode.window.showErrorMessage('Server already off.');
 			}
 		})
 	);
@@ -186,7 +192,7 @@ export function findFullLinkRegex(
 						length: fullURLMatches[i].length,
 						tooltip: `Open in Preview `,
 						data: url.pathname + url.search,
-						inEditor: false
+						inEditor: false,
 					};
 					links.push(tl);
 				}
@@ -200,7 +206,10 @@ export function findPathnameRegex(
 	links: Array<vscode.TerminalLink>
 ) {
 	// match relative links
-	const partialLinkRegex = new RegExp(`(?<=\\s)\\/([/(\\w%\\-.)]*)\\?*[\\w=]*`, 'g');
+	const partialLinkRegex = new RegExp(
+		`(?<=\\s)\\/([/(\\w%\\-.)]*)\\?*[\\w=]*`,
+		'g'
+	);
 	let partialLinkMatches;
 	do {
 		partialLinkMatches = partialLinkRegex.exec(input);
@@ -208,15 +217,15 @@ export function findPathnameRegex(
 			for (let i = 0; i < partialLinkMatches.length; i++) {
 				if (partialLinkMatches[i]) {
 					const link = partialLinkMatches[i];
-					const isDir = link.endsWith("/");
-					const tooltip = isDir ? "Reveal Folder ": "Open File ";
+					const isDir = link.endsWith('/');
+					const tooltip = isDir ? 'Reveal Folder ' : 'Open File ';
 					const tl = {
 						startIndex: partialLinkMatches.index,
 						length: partialLinkMatches[i].length,
 						tooltip: tooltip,
 						data: link,
 						inEditor: true,
-						isDir: isDir
+						isDir: isDir,
 					};
 					links.push(tl);
 				}
@@ -226,18 +235,23 @@ export function findPathnameRegex(
 }
 
 export function openRelativeLinkInWorkspace(file: string, isDir: boolean) {
-	const isWorkspaceFile = fs.existsSync(PathUtil.GetWorkspace()?.uri.fsPath + file);
-	const fullPath = isWorkspaceFile? (PathUtil.GetWorkspace()?.uri + file) : ("file:///" + PathUtil.DecodeLooseFilePath(file));
-	
+	const isWorkspaceFile = fs.existsSync(
+		PathUtil.GetWorkspace()?.uri.fsPath + file
+	);
+	const fullPath = isWorkspaceFile
+		? PathUtil.GetWorkspace()?.uri + file
+		: 'file:///' + PathUtil.DecodeLooseFilePath(file);
+
 	const uri = vscode.Uri.parse(fullPath);
 
 	if (isDir) {
 		if (!isWorkspaceFile) {
-			vscode.window.showErrorMessage("Cannot reveal folder. It is not in the open workspace.");
+			vscode.window.showErrorMessage(
+				'Cannot reveal folder. It is not in the open workspace.'
+			);
 		}
-		vscode.commands.executeCommand('revealInExplorer',uri);
+		vscode.commands.executeCommand('revealInExplorer', uri);
 	} else {
-		vscode.commands.executeCommand('vscode.open',uri);
+		vscode.commands.executeCommand('vscode.open', uri);
 	}
-	
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,17 +1,12 @@
 import { URL } from 'url';
 import * as vscode from 'vscode';
-import * as path from 'path';
+import * as fs from 'fs';
 import { BrowserPreview } from './editorPreview/browserPreview';
 import { getWebviewOptions, Manager } from './manager';
 import { HOST } from './utils/constants';
-import { GetPreviewType, SETTINGS_SECTION_ID } from './utils/settingsUtil';
-import {
-	DecodeLooseFilePath,
-	GetActiveFile,
-	GetWorkspace,
-	GetWorkspacePath,
-} from './utils/utils';
-import * as fs from 'fs';
+import { SETTINGS_SECTION_ID, SettingUtil } from './utils/settingsUtil';
+import { PathUtil } from './utils/pathUtil';
+import { GetActiveFile } from './utils/utils';
 
 export function activate(context: vscode.ExtensionContext) {
 	const manager = new Manager(context.extensionUri);
@@ -26,7 +21,7 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand(
 			`${SETTINGS_SECTION_ID}.start.preview.atFile`,
 			(file?: any) => {
-				const previewType = GetPreviewType(context.extensionUri);
+				const previewType = SettingUtil.GetPreviewType(context.extensionUri);
 				vscode.commands.executeCommand(
 					`${SETTINGS_SECTION_ID}.start.${previewType}.atFile`,
 					file
@@ -38,7 +33,7 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand(
 			`${SETTINGS_SECTION_ID}.start.preview.atIndex`,
 			(file?: any) => {
-				const previewType = GetPreviewType(context.extensionUri);
+				const previewType = SettingUtil.GetPreviewType(context.extensionUri);
 				vscode.commands.executeCommand(
 					`${SETTINGS_SECTION_ID}.start.${previewType}.atIndex`,
 					file
@@ -231,8 +226,8 @@ export function findPathnameRegex(
 }
 
 export function openRelativeLinkInWorkspace(file: string, isDir: boolean) {
-	const isWorkspaceFile = fs.existsSync(GetWorkspace()?.uri.fsPath + file);
-	const fullPath = isWorkspaceFile? (GetWorkspace()?.uri + file) : ("file:///" + DecodeLooseFilePath(file));
+	const isWorkspaceFile = fs.existsSync(PathUtil.GetWorkspace()?.uri.fsPath + file);
+	const fullPath = isWorkspaceFile? (PathUtil.GetWorkspace()?.uri + file) : ("file:///" + PathUtil.DecodeLooseFilePath(file));
 	
 	const uri = vscode.Uri.parse(fullPath);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import { GetPreviewType, SETTINGS_SECTION_ID } from './utils/settingsUtil';
 import {
 	DecodeLooseFilePath,
 	GetActiveFile,
+	GetWorkspace,
 	GetWorkspacePath,
 } from './utils/utils';
 import * as fs from 'fs';
@@ -214,7 +215,7 @@ export function findPathnameRegex(
 					const tl = {
 						startIndex: partialLinkMatches.index,
 						length: partialLinkMatches[i].length,
-						tooltip: `Reveal in Explorer `,
+						tooltip: `Reveal File `,
 						data: partialLinkMatches[i],
 						inEditor: true
 					};
@@ -226,12 +227,20 @@ export function findPathnameRegex(
 }
 
 export function openRelativeLinkInWorkspace(file: string) {
-	const fullPath = path.join(GetWorkspacePath() ?? '', file);
 
-	// if (!fs.existsSync(fullPath)) {
-	// 	fullPath = DecodeLooseFilePath(file);
-	// } 
+	let uri;
+	if (fs.existsSync(GetWorkspace()?.uri.fsPath + file)) {
+		const fullPath = GetWorkspace()?.uri + file;
+		uri = vscode.Uri.parse(fullPath);
+	} else {
+		const fullPath = "file:///" + DecodeLooseFilePath(file);
+		uri = vscode.Uri.parse(fullPath);
+	}
 	
-	const uri = vscode.Uri.parse(fullPath);
-	vscode.commands.executeCommand('revealInExplorer',uri);
+	if (file.endsWith("/")) {
+		vscode.commands.executeCommand('revealInExplorer',uri);
+	} else {
+		vscode.commands.executeCommand('vscode.open',uri);
+	}
+	
 }

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -224,7 +224,7 @@ export class Manager extends Disposable {
 		) {
 			vscode.window
 				.showWarningMessage(
-					'Previewing a file that is not a child of the server root. For best functionality, please open a workspace at the project root.',
+					'Previewing a file that is not a child of the server root. To see fully correct relative file links, please open a workspace at the project root.',
 					DONT_SHOW_AGAIN
 				)
 				.then((selection: vscode.MessageItem | undefined) => {

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -188,7 +188,7 @@ export class Manager extends Disposable {
 	}
 
 	// caller is reponsible for only calling this if nothing is using the server
-	public closeServer(): void {
+	public closeServer(): boolean {
 		if (this._server.isRunning) {
 			this._server.closeServer();
 
@@ -204,9 +204,14 @@ export class Manager extends Disposable {
 				this._serverPort = GetConfig(this._extensionUri).portNum;
 				this._serverPortNeedsUpdate = false;
 			}
+			return true;
 		}
+		return false;
 	}
 
+	public inServerWorkspace(file: string) {
+		return this._server.canGetPath(file);
+	}
 	private startPreview(panel: vscode.WebviewPanel, file: string) {
 
 		if (this._currentTimeout) {

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -8,7 +8,11 @@ import {
 	ServerStartedStatus,
 	ServerTaskProvider,
 } from './task/serverTaskProvider';
-import { Settings, SETTINGS_SECTION_ID, SettingUtil } from './utils/settingsUtil';
+import {
+	Settings,
+	SETTINGS_SECTION_ID,
+	SettingUtil,
+} from './utils/settingsUtil';
 
 export interface serverMsg {
 	method: string;
@@ -99,7 +103,9 @@ export class Manager extends Disposable {
 				const newPortNum = SettingUtil.GetConfig(this._extensionUri).portNum;
 				if (newPortNum != this._serverPort) {
 					if (!this._server.isRunning) {
-						this._serverPort = SettingUtil.GetConfig(this._extensionUri).portNum;
+						this._serverPort = SettingUtil.GetConfig(
+							this._extensionUri
+						).portNum;
 					} else {
 						this._serverPortNeedsUpdate = true;
 					}
@@ -110,9 +116,9 @@ export class Manager extends Disposable {
 
 	public createOrShowPreview(
 		panel: vscode.WebviewPanel | undefined = undefined,
-		file = '/', relative = true
+		file = '/',
+		relative = true
 	): void {
-		
 		file = this.transformNonRelativeFile(relative, file);
 
 		const column = vscode.ViewColumn.Beside;
@@ -146,7 +152,8 @@ export class Manager extends Disposable {
 	public showPreviewInBrowser(file = '/', relative = true) {
 		if (!this._serverTaskProvider.isRunning) {
 			this._serverTaskProvider.extRunTask(
-				SettingUtil.GetConfig(this._extensionUri).browserPreviewLaunchServerLogging
+				SettingUtil.GetConfig(this._extensionUri)
+					.browserPreviewLaunchServerLogging
 			);
 		}
 		file = this.transformNonRelativeFile(relative, file);
@@ -160,7 +167,6 @@ export class Manager extends Disposable {
 	}
 
 	public openServer(fromTask = false): boolean {
-		
 		if (!this._server.isRunning) {
 			return this._server.openServer(this._serverPort);
 		} else if (fromTask) {
@@ -200,7 +206,6 @@ export class Manager extends Disposable {
 	}
 
 	private transformNonRelativeFile(relative: boolean, file: string): string {
-
 		if (!relative) {
 			if (!this._server.canGetPath(file)) {
 				this.notifyLooseFileOpen();
@@ -213,19 +218,25 @@ export class Manager extends Disposable {
 	}
 
 	private notifyLooseFileOpen() {
-		if (!this._notifiedAboutLooseFiles && SettingUtil.GetConfig(this._extensionUri).notifyOnOpenLooseFile) {
-			vscode.window.showWarningMessage("Previewing a file that is not a child of the server root. For best functionality, please open a workspace at the project root.", DONT_SHOW_AGAIN)
-			.then((selection: vscode.MessageItem | undefined) => {
-				if (selection == DONT_SHOW_AGAIN) {
-					SettingUtil.UpdateSettings(Settings.notifyOnOpenLooseFile, false);
-				}
-			});
+		if (
+			!this._notifiedAboutLooseFiles &&
+			SettingUtil.GetConfig(this._extensionUri).notifyOnOpenLooseFile
+		) {
+			vscode.window
+				.showWarningMessage(
+					'Previewing a file that is not a child of the server root. For best functionality, please open a workspace at the project root.',
+					DONT_SHOW_AGAIN
+				)
+				.then((selection: vscode.MessageItem | undefined) => {
+					if (selection == DONT_SHOW_AGAIN) {
+						SettingUtil.UpdateSettings(Settings.notifyOnOpenLooseFile, false);
+					}
+				});
 		}
 		this._notifiedAboutLooseFiles = true;
 	}
 
 	private startEmbeddedPreview(panel: vscode.WebviewPanel, file: string) {
-
 		if (this._currentTimeout) {
 			clearTimeout(this._currentTimeout);
 		}
@@ -242,7 +253,9 @@ export class Manager extends Disposable {
 
 		this.currentPanel.onDispose(() => {
 			this.currentPanel = undefined;
-			const closeServerDelay = SettingUtil.GetConfig(this._extensionUri).serverKeepAliveAfterEmbeddedPreviewClose;
+			const closeServerDelay = SettingUtil.GetConfig(
+				this._extensionUri
+			).serverKeepAliveAfterEmbeddedPreviewClose;
 			this._currentTimeout = setTimeout(() => {
 				// set a delay to server shutdown to avoid bad performance from re-opening/closing server.
 				if (this._server.isRunning && !this._serverTaskProvider.isRunning) {
@@ -250,7 +263,6 @@ export class Manager extends Disposable {
 				}
 				this._previewActive = false;
 			}, Math.floor(closeServerDelay * 1000 * 60));
-
 		});
 	}
 

--- a/src/server/httpServer.ts
+++ b/src/server/httpServer.ts
@@ -84,11 +84,15 @@ export class HttpServer extends Disposable {
 			let stream;
 
 			if (!fs.existsSync(absoluteReadPath)) {
-				stream = this._contentLoader.createPageDoesNotExist(absoluteReadPath);
-				res.writeHead(404);
-				this.reportStatus(req, res);
-				stream.pipe(res);
-				return;
+
+				stream = this._contentLoader.decodeUrlPath(URLPathName);
+				if (!stream) {
+					stream = this._contentLoader.createPageDoesNotExist(absoluteReadPath);
+					res.writeHead(404);
+					this.reportStatus(req, res);
+					stream.pipe(res);
+					return;
+				}
 			} else if (fs.statSync(absoluteReadPath).isDirectory()) {
 				if (!URLPathName.endsWith('/')) {
 					const queries =

--- a/src/server/httpServer.ts
+++ b/src/server/httpServer.ts
@@ -7,7 +7,8 @@ import { ContentLoader } from './serverUtils/contentLoader';
 import { HTMLInjector } from './serverUtils/HTMLInjector';
 import { HOST } from '../utils/constants';
 import { serverMsg } from '../manager';
-import { DecodeLooseFilePath, isFileInjectable } from '../utils/utils';
+import { isFileInjectable } from '../utils/utils';
+import { PathUtil } from '../utils/pathUtil';
 
 export class HttpServer extends Disposable {
 	private _server: any;
@@ -86,7 +87,7 @@ export class HttpServer extends Disposable {
 			let stream;
 
 			if (!fs.existsSync(absoluteReadPath)) {
-				const decodedReadPath = DecodeLooseFilePath(URLPathName);
+				const decodedReadPath = PathUtil.DecodeLooseFilePath(URLPathName);
 				looseFile = true;
 				if (fs.existsSync(decodedReadPath)) {
 					absoluteReadPath = decodedReadPath;

--- a/src/server/httpServer.ts
+++ b/src/server/httpServer.ts
@@ -87,7 +87,9 @@ export class HttpServer extends Disposable {
 			let stream;
 
 			if (!fs.existsSync(absoluteReadPath)) {
-				const decodedReadPath = PathUtil.DecodeLooseFilePath(URLPathName);
+				const decodedReadPath = path.normalize(
+					PathUtil.DecodeLooseFilePath(URLPathName)
+				);
 				looseFile = true;
 				if (fs.existsSync(decodedReadPath)) {
 					absoluteReadPath = decodedReadPath;

--- a/src/server/httpServer.ts
+++ b/src/server/httpServer.ts
@@ -89,7 +89,7 @@ export class HttpServer extends Disposable {
 				if (fs.existsSync(decodedReadPath)) {
 					absoluteReadPath = decodedReadPath;
 				} else {
-					stream = this._contentLoader.createPageDoesNotExist(absoluteReadPath);
+					stream = this._contentLoader.createPageDoesNotExist(unescape(absoluteReadPath));
 					res.writeHead(404);
 					this.reportStatus(req, res);
 					stream.pipe(res);

--- a/src/server/serverManager.ts
+++ b/src/server/serverManager.ts
@@ -26,12 +26,10 @@ export class Server extends Disposable {
 	private _isServerOn = false;
 	private _workspacePath: string | undefined;
 
-	constructor(
-		extensionUri: vscode.Uri
-	) {
+	constructor(extensionUri: vscode.Uri) {
 		super();
 		this._extensionUri = extensionUri;
-		this._httpServer = this._register(new HttpServer());
+		this._httpServer = this._register(new HttpServer(extensionUri));
 		this._wsServer = this._register(new WSServer());
 		this._statusBar = this._register(new StatusBarNotifier(extensionUri));
 		this._workspacePath = GetWorkspacePath();
@@ -145,7 +143,7 @@ export class Server extends Disposable {
 
 	public getFileRelativeToWorkspace(path: string): string {
 		const workspaceFolder = this._workspacePath;
-	
+
 		if (workspaceFolder && path.startsWith(workspaceFolder)) {
 			return path.substr(workspaceFolder.length).replace(/\\/gi, '/');
 		} else {
@@ -197,23 +195,19 @@ export class Server extends Disposable {
 		this.showServerStatusMessage('Server Closed');
 	}
 
-	public openServer(port: number,): boolean {
+	public openServer(port: number): boolean {
 		if (this._extensionUri) {
 			// initialize websockets to use port after http server port
-			this._httpServer.setInjectorWSPort(port + 1, this._extensionUri);
+			this._httpServer.setInjectorWSPort(port + 1);
 
-			this._httpServer.start(port, this._workspacePath ?? "");
+			this._httpServer.start(port, this._workspacePath ?? '');
 			return true;
 		}
 		return false;
 	}
 
 	private httpServerConnected() {
-		this._wsServer.start(
-			this._httpServer.port + 1,
-			this._workspacePath ?? "",
-			this._extensionUri
-		);
+		this._wsServer.start(this._httpServer.port + 1, this._workspacePath ?? '');
 	}
 
 	private wsServerConnected() {

--- a/src/server/serverManager.ts
+++ b/src/server/serverManager.ts
@@ -5,13 +5,12 @@ import { HttpServer } from './httpServer';
 import { StatusBarNotifier } from './serverUtils/statusBarNotifier';
 import {
 	AutoRefreshPreview,
-	GetConfig,
-	UpdateSettings,
+	SettingUtil,
 	Settings,
 } from '../utils/settingsUtil';
 import { DONT_SHOW_AGAIN } from '../utils/constants';
 import { serverMsg } from '../manager';
-import { GetWorkspacePath } from '../utils/utils';
+import { PathUtil } from '../utils/pathUtil';
 
 export interface PortInfo {
 	port?: number;
@@ -32,7 +31,7 @@ export class Server extends Disposable {
 		this._httpServer = this._register(new HttpServer(extensionUri));
 		this._wsServer = this._register(new WSServer());
 		this._statusBar = this._register(new StatusBarNotifier(extensionUri));
-		this._workspacePath = GetWorkspacePath();
+		this._workspacePath = PathUtil.GetWorkspacePath();
 
 		this._register(
 			vscode.workspace.onDidChangeTextDocument((e) => {
@@ -174,14 +173,14 @@ export class Server extends Disposable {
 
 	private get _reloadOnAnyChange() {
 		return (
-			GetConfig(this._extensionUri).autoRefreshPreview ==
+			SettingUtil.GetConfig(this._extensionUri).autoRefreshPreview ==
 			AutoRefreshPreview.onAnyChange
 		);
 	}
 
 	private get _reloadOnSave() {
 		return (
-			GetConfig(this._extensionUri).autoRefreshPreview ==
+			SettingUtil.GetConfig(this._extensionUri).autoRefreshPreview ==
 			AutoRefreshPreview.onSave
 		);
 	}
@@ -221,12 +220,12 @@ export class Server extends Disposable {
 	}
 
 	private showServerStatusMessage(messsage: string) {
-		if (GetConfig(this._extensionUri).showServerStatusPopUps) {
+		if (SettingUtil.GetConfig(this._extensionUri).showServerStatusPopUps) {
 			vscode.window
 				.showInformationMessage(messsage, DONT_SHOW_AGAIN)
 				.then((selection: vscode.MessageItem | undefined) => {
 					if (selection == DONT_SHOW_AGAIN) {
-						UpdateSettings(Settings.showServerStatusPopUps, false);
+						SettingUtil.UpdateSettings(Settings.showServerStatusPopUps, false);
 					}
 				});
 		}

--- a/src/server/serverManager.ts
+++ b/src/server/serverManager.ts
@@ -36,10 +36,6 @@ export class Server extends Disposable {
 		this._statusBar = this._register(new StatusBarNotifier(extensionUri));
 		this._workspacePath = GetWorkspacePath();
 
-		if (!this._workspacePath) {
-			vscode.window.showWarningMessage("Cannot find a root to start a server on. Live Server may not preview optimally.");
-		} 
-
 		this._register(
 			vscode.workspace.onDidChangeTextDocument((e) => {
 				if (

--- a/src/server/serverManager.ts
+++ b/src/server/serverManager.ts
@@ -37,7 +37,7 @@ export class Server extends Disposable {
 		this._workspacePath = GetWorkspacePath();
 
 		if (!this._workspacePath) {
-			vscode.window.showErrorMessage("Cannot find a root to start a server on. Live Server may not preview optimally.");
+			vscode.window.showWarningMessage("Cannot find a root to start a server on. Live Server may not preview optimally.");
 		} 
 
 		this._register(
@@ -202,25 +202,22 @@ export class Server extends Disposable {
 	}
 
 	public openServer(port: number,): boolean {
-		if (this._workspacePath && this._extensionUri) {
+		if (this._extensionUri) {
 			// initialize websockets to use port after http server port
 			this._httpServer.setInjectorWSPort(port + 1, this._extensionUri);
 
-			this._httpServer.start(port, this._workspacePath);
+			this._httpServer.start(port, this._workspacePath ?? "");
 			return true;
 		}
-		this.showServerStatusMessage('Server Failed To Open');
 		return false;
 	}
 
 	private httpServerConnected() {
-		if (this._workspacePath) {
-			this._wsServer.start(
-				this._httpServer.port + 1,
-				this._workspacePath,
-				this._extensionUri
-			);
-		}
+		this._wsServer.start(
+			this._httpServer.port + 1,
+			this._workspacePath ?? "",
+			this._extensionUri
+		);
 	}
 
 	private wsServerConnected() {

--- a/src/server/serverUtils/contentLoader.ts
+++ b/src/server/serverUtils/contentLoader.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { Disposable } from '../../utils/dispose';
-import { FormatFileSize, FormatDateTime, isFileInjectable, DecodeLooseFilePath } from '../../utils/utils';
+import { FormatFileSize, FormatDateTime, isFileInjectable } from '../../utils/utils';
 import { HTMLInjector } from './HTMLInjector';
 
 export interface IndexFileEntry {

--- a/src/server/serverUtils/contentLoader.ts
+++ b/src/server/serverUtils/contentLoader.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { Disposable } from '../../utils/dispose';
-import { FormatFileSize, FormatDateTime, isFileInjectable } from '../../utils/utils';
+import { FormatFileSize, FormatDateTime, isFileInjectable, DecodeLooseFilePath } from '../../utils/utils';
 import { HTMLInjector } from './HTMLInjector';
 
 export interface IndexFileEntry {
@@ -127,11 +127,19 @@ export class ContentLoader extends Disposable {
 		return Stream.Readable.from(htmlString);
 	}
 
+	public decodeUrlPath(urlPath: string): Stream.Readable | fs.ReadStream | undefined {
+		const readPath = DecodeLooseFilePath(urlPath);
+
+		if (!fs.existsSync(readPath)) {
+			return undefined;
+		}
+		return this.getFileStream(readPath);
+	}
+
 	public getFileStream(
 		readPath: string
 	): Stream.Readable | fs.ReadStream | undefined {
 		const workspaceDocuments = vscode.workspace.textDocuments;
-
 		let i = 0;
 		let stream;
 		while (i < workspaceDocuments.length) {

--- a/src/server/serverUtils/contentLoader.ts
+++ b/src/server/serverUtils/contentLoader.ts
@@ -128,15 +128,6 @@ export class ContentLoader extends Disposable {
 		return Stream.Readable.from(htmlString);
 	}
 
-	// public decodeUrlPath(urlPath: string): Stream.Readable | fs.ReadStream | undefined {
-	// 	const readPath = DecodeLooseFilePath(urlPath);
-
-	// 	if (!fs.existsSync(readPath)) {
-	// 		return undefined;
-	// 	}
-	// 	return this.getFileStream(readPath);
-	// }
-
 	public getFileStream(
 		readPath: string
 	): Stream.Readable | fs.ReadStream | undefined {

--- a/src/server/serverUtils/contentLoader.ts
+++ b/src/server/serverUtils/contentLoader.ts
@@ -43,7 +43,8 @@ export class ContentLoader extends Disposable {
 
 	public createIndexPage(
 		readPath: string,
-		relativePath: string
+		relativePath: string,
+		titlePath = relativePath
 	): Stream.Readable {
 		const childFiles = fs.readdirSync(readPath);
 
@@ -109,10 +110,10 @@ export class ContentLoader extends Disposable {
 						padding:4px;
 					}
 				</style>
-				<title>Index of ${relativePath}</title>
+				<title>Index of ${titlePath}</title>
 			</head>
 			<body>
-			<h1>Index of ${relativePath}</h1>
+			<h1>Index of ${titlePath}</h1>
 
 			<table>
 				<th>Name</th><th>Size</th><th>Date Modified</th>
@@ -127,14 +128,14 @@ export class ContentLoader extends Disposable {
 		return Stream.Readable.from(htmlString);
 	}
 
-	public decodeUrlPath(urlPath: string): Stream.Readable | fs.ReadStream | undefined {
-		const readPath = DecodeLooseFilePath(urlPath);
+	// public decodeUrlPath(urlPath: string): Stream.Readable | fs.ReadStream | undefined {
+	// 	const readPath = DecodeLooseFilePath(urlPath);
 
-		if (!fs.existsSync(readPath)) {
-			return undefined;
-		}
-		return this.getFileStream(readPath);
-	}
+	// 	if (!fs.existsSync(readPath)) {
+	// 		return undefined;
+	// 	}
+	// 	return this.getFileStream(readPath);
+	// }
 
 	public getFileStream(
 		readPath: string

--- a/src/server/serverUtils/statusBarNotifier.ts
+++ b/src/server/serverUtils/statusBarNotifier.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { Disposable } from '../../utils/dispose';
-import { GetConfig } from '../../utils/settingsUtil';
+import { SettingUtil } from '../../utils/settingsUtil';
 
 // flow is inspired by status bar in original Live Server extension
 // https://github.com/ritwickdey/vscode-live-server/blob/master/src/StatusbarUi.ts
@@ -21,7 +21,7 @@ export class StatusBarNotifier extends Disposable {
 
 	public ServerOn(port: number) {
 		this._on = true;
-		if (GetConfig(this._extensionUri).showStatusBarItem) {
+		if (SettingUtil.GetConfig(this._extensionUri).showStatusBarItem) {
 			this._statusBar.show();
 		}
 
@@ -35,7 +35,7 @@ export class StatusBarNotifier extends Disposable {
 	}
 
 	public updateConfigurations() {
-		if (GetConfig(this._extensionUri).showStatusBarItem) {
+		if (SettingUtil.GetConfig(this._extensionUri).showStatusBarItem) {
 			if (this._on) {
 				this._statusBar.show();
 			}

--- a/src/server/wsServer.ts
+++ b/src/server/wsServer.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { URL } from 'url';
 import { Disposable } from '../utils/dispose';
-import { isFileInjectable } from '../utils/utils';
+import { DecodeLooseFilePath, isFileInjectable } from '../utils/utils';
 
 export class WSServer extends Disposable {
 	private _wss: WebSocket.Server | undefined;
@@ -87,7 +87,16 @@ export class WSServer extends Disposable {
 		urlString: string
 	): { injectable: boolean; pathname: string } {
 		const url = new URL(urlString);
-		const absolutePath = path.join(basePath, url.pathname);
+		let absolutePath = path.join(basePath, url.pathname);
+
+		if (!fs.existsSync(absolutePath))
+		{
+			absolutePath = DecodeLooseFilePath(absolutePath);
+			if (!fs.existsSync(absolutePath)) {
+				return { injectable: false, pathname: url.pathname };
+			}
+		}
+		
 		if (
 			fs.statSync(absolutePath).isDirectory() ||
 			isFileInjectable(absolutePath)

--- a/src/server/wsServer.ts
+++ b/src/server/wsServer.ts
@@ -4,7 +4,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { URL } from 'url';
 import { Disposable } from '../utils/dispose';
-import { DecodeLooseFilePath, isFileInjectable } from '../utils/utils';
+import { isFileInjectable } from '../utils/utils';
+import { PathUtil } from '../utils/pathUtil';
 
 export class WSServer extends Disposable {
 	private _wss: WebSocket.Server | undefined;
@@ -90,7 +91,7 @@ export class WSServer extends Disposable {
 		let absolutePath = path.join(basePath, url.pathname);
 
 		if (!fs.existsSync(absolutePath)) {
-			absolutePath = DecodeLooseFilePath(absolutePath);
+			absolutePath = PathUtil.DecodeLooseFilePath(absolutePath);
 			if (!fs.existsSync(absolutePath)) {
 				return { injectable: false, pathname: url.pathname };
 			}

--- a/src/server/wsServer.ts
+++ b/src/server/wsServer.ts
@@ -26,9 +26,9 @@ export class WSServer extends Disposable {
 	);
 	public readonly onConnected = this._onConnected.event;
 
-	public start(ws_port: number, basePath: string, extensionUri: vscode.Uri) {
+	public start(ws_port: number, basePath: string) {
 		this._ws_port = ws_port;
-		this.startWSServer(basePath, extensionUri);
+		this.startWSServer(basePath);
 	}
 
 	public close() {
@@ -37,28 +37,26 @@ export class WSServer extends Disposable {
 		}
 	}
 
-	private startWSServer(basePath: string, extensionUri: vscode.Uri): boolean {
+	private startWSServer(basePath: string): boolean {
 		this._wss = new WebSocket.Server({ port: this._ws_port });
 		this._wss.on('connection', (ws: any) =>
 			this.handleWSConnection(basePath, ws)
 		);
-		this._wss.on('error', (err: any) =>
-			this.handleWSError(basePath, extensionUri, err)
-		);
-		this._wss.on('listening', () => this.handleWSListen(extensionUri));
+		this._wss.on('error', (err: any) => this.handleWSError(basePath, err));
+		this._wss.on('listening', () => this.handleWSListen());
 		return true;
 	}
 
-	private handleWSError(basePath: string, extensionUri: vscode.Uri, err: any) {
+	private handleWSError(basePath: string, err: any) {
 		if (err.code == 'EADDRINUSE') {
 			this._ws_port++;
-			this.startWSServer(basePath, extensionUri);
+			this.startWSServer(basePath);
 		} else {
 			console.log(`Unknown error: ${err}`);
 		}
 	}
 
-	private handleWSListen(extensionUri: vscode.Uri) {
+	private handleWSListen() {
 		console.log(`Websocket server is running on port ${this._ws_port}`);
 		this._onConnected.fire(this._ws_port);
 	}
@@ -73,9 +71,11 @@ export class WSServer extends Disposable {
 						parsedMessage.url
 					);
 					if (!results.injectable) {
-						ws.send(
-							`{"command":"foundNonInjectable","path":"${results.pathname}"}`
-						);
+						const sendData = {
+							command: 'foundNonInjectable',
+							path: results.pathname,
+						};
+						ws.send(JSON.stringify(sendData));
 					}
 				}
 			}
@@ -89,14 +89,13 @@ export class WSServer extends Disposable {
 		const url = new URL(urlString);
 		let absolutePath = path.join(basePath, url.pathname);
 
-		if (!fs.existsSync(absolutePath))
-		{
+		if (!fs.existsSync(absolutePath)) {
 			absolutePath = DecodeLooseFilePath(absolutePath);
 			if (!fs.existsSync(absolutePath)) {
 				return { injectable: false, pathname: url.pathname };
 			}
 		}
-		
+
 		if (
 			fs.statSync(absolutePath).isDirectory() ||
 			isFileInjectable(absolutePath)
@@ -109,7 +108,7 @@ export class WSServer extends Disposable {
 	public refreshBrowsers(): void {
 		if (this._wss) {
 			this._wss.clients.forEach((client: any) =>
-				client.send(`{"command":"reload"}`)
+				client.send(JSON.stringify({ command: 'reload' }))
 			);
 		}
 	}

--- a/src/task/serverTaskProvider.ts
+++ b/src/task/serverTaskProvider.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { serverMsg } from '../manager';
 import { Disposable } from '../utils/dispose';
-import { GetWorkspace } from '../utils/utils';
+import { PathUtil } from '../utils/pathUtil';
 import { ServerTaskTerminal } from './serverTaskTerminal';
 
 interface ServerTaskDefinition extends vscode.TaskDefinition {
@@ -133,7 +133,7 @@ export class ServerTaskProvider
 		if (this._terminal && this._terminal.running) {
 			return new vscode.Task(
 				definition,
-				GetWorkspace() ?? vscode.TaskScope.Workspace,
+				PathUtil.GetWorkspace() ?? vscode.TaskScope.Workspace,
 				termName,
 				ServerTaskProvider.CustomBuildScriptType,
 				undefined

--- a/src/task/serverTaskProvider.ts
+++ b/src/task/serverTaskProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { serverMsg } from '../manager';
 import { Disposable } from '../utils/dispose';
+import { GetWorkspace } from '../utils/utils';
 import { ServerTaskTerminal } from './serverTaskTerminal';
 
 interface ServerTaskDefinition extends vscode.TaskDefinition {
@@ -132,7 +133,7 @@ export class ServerTaskProvider
 		if (this._terminal && this._terminal.running) {
 			return new vscode.Task(
 				definition,
-				vscode.TaskScope.Workspace,
+				GetWorkspace() ?? vscode.TaskScope.Workspace,
 				termName,
 				ServerTaskProvider.CustomBuildScriptType,
 				undefined
@@ -179,3 +180,4 @@ export class ServerTaskProvider
 	);
 	public readonly onDispose = this._onDisposeEmitter.event;
 }
+

--- a/src/task/serverTaskProvider.ts
+++ b/src/task/serverTaskProvider.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode';
 import { serverMsg } from '../manager';
 import { Disposable } from '../utils/dispose';
-import { GetWorkspace } from '../utils/utils';
 import { ServerTaskTerminal } from './serverTaskTerminal';
 
 interface ServerTaskDefinition extends vscode.TaskDefinition {
@@ -130,11 +129,10 @@ export class ServerTaskProvider
 		for (const i in args) {
 			termName += ` ${args[i]}`;
 		}
-		const currentWorkspace = GetWorkspace();
 		if (this._terminal && this._terminal.running) {
 			return new vscode.Task(
 				definition,
-				currentWorkspace ?? vscode.TaskScope.Workspace,
+				vscode.TaskScope.Workspace,
 				termName,
 				ServerTaskProvider.CustomBuildScriptType,
 				undefined

--- a/src/task/serverTaskProvider.ts
+++ b/src/task/serverTaskProvider.ts
@@ -180,4 +180,3 @@ export class ServerTaskProvider
 	);
 	public readonly onDispose = this._onDisposeEmitter.event;
 }
-

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 
 export const WS_PORTNUM_PLACEHOLDER = '${WS_PORTNUM}';
+
 export const INIT_PANEL_TITLE = '/';
 
 export const GO_TO_SETTINGS: vscode.MessageItem = {

--- a/src/utils/pathUtil.ts
+++ b/src/utils/pathUtil.ts
@@ -1,0 +1,39 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export class PathUtil {
+	public static GetWorkspace(): vscode.WorkspaceFolder | undefined {
+		return vscode.workspace.workspaceFolders?.[0];
+	}
+	
+	public static GetWorkspacePath(): string | undefined {
+		return PathUtil.GetWorkspace()?.uri.fsPath;
+	}
+	
+	public static GetActiveFolderPath() {
+		const path = vscode.window.activeTextEditor?.document.uri.fsPath ?? '';
+		return PathUtil.GetParentDir(path);
+	}
+	
+	public static GetParentDir(file: string) {
+		return path.dirname(file);
+	}
+	
+	public static GetFileName(file: string) {
+		return path.basename(file);
+	}
+	
+	public static EncodeLooseFilePath(path: string) {
+		return '/' + escape(PathUtil.GetParentDir(path)) + '/' + PathUtil.GetFileName(path);
+	}
+	
+	public static DecodeLooseFilePath(file: string) {
+		return unescape(file).substr(1);
+	}
+	
+	public static IsLooseFilePath(file: string) {
+		const absPath = path.join(PathUtil.GetWorkspacePath() ?? '', file);
+		return !fs.existsSync(absPath);
+	}
+}

--- a/src/utils/pathUtil.ts
+++ b/src/utils/pathUtil.ts
@@ -6,32 +6,37 @@ export class PathUtil {
 	public static GetWorkspace(): vscode.WorkspaceFolder | undefined {
 		return vscode.workspace.workspaceFolders?.[0];
 	}
-	
+
 	public static GetWorkspacePath(): string | undefined {
 		return PathUtil.GetWorkspace()?.uri.fsPath;
 	}
-	
+
 	public static GetActiveFolderPath() {
 		const path = vscode.window.activeTextEditor?.document.uri.fsPath ?? '';
 		return PathUtil.GetParentDir(path);
 	}
-	
+
 	public static GetParentDir(file: string) {
 		return path.dirname(file);
 	}
-	
+
 	public static GetFileName(file: string) {
 		return path.basename(file);
 	}
-	
+
 	public static EncodeLooseFilePath(path: string) {
-		return '/' + escape(PathUtil.GetParentDir(path)) + '/' + PathUtil.GetFileName(path);
+		return (
+			'/' +
+			escape(PathUtil.GetParentDir(path)) +
+			'/' +
+			PathUtil.GetFileName(path)
+		);
 	}
-	
+
 	public static DecodeLooseFilePath(file: string) {
 		return unescape(file).substr(1);
 	}
-	
+
 	public static IsLooseFilePath(file: string) {
 		const absPath = path.join(PathUtil.GetWorkspacePath() ?? '', file);
 		return !fs.existsSync(absPath);

--- a/src/utils/settingsUtil.ts
+++ b/src/utils/settingsUtil.ts
@@ -112,14 +112,4 @@ export class SettingUtil {
 				}
 			});
 	}
-
-
 }
-
-
-
-
-
-
-
-

--- a/src/utils/settingsUtil.ts
+++ b/src/utils/settingsUtil.ts
@@ -12,8 +12,7 @@ export const Settings: any = {
 	openPreviewTarget: 'openPreviewTarget',
 	serverKeepAliveAfterEmbeddedPreviewClose:
 		'serverKeepAliveAfterEmbeddedPreviewClose',
-	notifyOnOpenLooseFile:
-		'notifyOnOpenLooseFile',
+	notifyOnOpenLooseFile: 'notifyOnOpenLooseFile',
 };
 
 interface LiveServerConfigItem {

--- a/src/utils/settingsUtil.ts
+++ b/src/utils/settingsUtil.ts
@@ -12,6 +12,8 @@ export const Settings: any = {
 	openPreviewTarget: 'openPreviewTarget',
 	serverKeepAliveAfterEmbeddedPreviewClose:
 		'serverKeepAliveAfterEmbeddedPreviewClose',
+	notifyOnOpenLooseFile:
+		'notifyOnOpenLooseFile',
 };
 
 interface LiveServerConfigItem {
@@ -22,6 +24,7 @@ interface LiveServerConfigItem {
 	browserPreviewLaunchServerLogging: boolean;
 	openPreviewTarget: OpenPreviewTarget;
 	serverKeepAliveAfterEmbeddedPreviewClose: number;
+	notifyOnOpenLooseFile: boolean;
 }
 
 export enum AutoRefreshPreview {
@@ -67,6 +70,10 @@ export function GetConfig(resource: vscode.Uri): LiveServerConfigItem {
 		serverKeepAliveAfterEmbeddedPreviewClose: config.get<number>(
 			Settings.serverKeepAliveAfterEmbeddedPreviewClose,
 			20
+		),
+		notifyOnOpenLooseFile: config.get<boolean>(
+			Settings.notifyOnOpenLooseFile,
+			true
 		),
 	};
 }

--- a/src/utils/settingsUtil.ts
+++ b/src/utils/settingsUtil.ts
@@ -1,21 +1,7 @@
 import * as vscode from 'vscode';
 import { GO_TO_SETTINGS } from './constants';
 
-export const SETTINGS_SECTION_ID = 'LiveServer';
-
-export const Settings: any = {
-	portNum: 'portNum',
-	showStatusBarItem: 'showStatusBarItem',
-	showServerStatusPopUps: 'showServerStatusPopUps',
-	autoRefreshPreview: 'autoRefreshPreview',
-	browserPreviewLaunchServerLogging: 'browserPreviewLaunchServerLogging',
-	openPreviewTarget: 'openPreviewTarget',
-	serverKeepAliveAfterEmbeddedPreviewClose:
-		'serverKeepAliveAfterEmbeddedPreviewClose',
-	notifyOnOpenLooseFile: 'notifyOnOpenLooseFile',
-};
-
-interface LiveServerConfigItem {
+export interface LiveServerConfigItem {
 	portNum: number;
 	showStatusBarItem: boolean;
 	showServerStatusPopUps: boolean;
@@ -37,80 +23,103 @@ export enum OpenPreviewTarget {
 	externalBrowser = 'External Browser',
 }
 
+export const SETTINGS_SECTION_ID = 'LiveServer';
+
+export const Settings: any = {
+	portNum: 'portNum',
+	showStatusBarItem: 'showStatusBarItem',
+	showServerStatusPopUps: 'showServerStatusPopUps',
+	autoRefreshPreview: 'autoRefreshPreview',
+	browserPreviewLaunchServerLogging: 'browserPreviewLaunchServerLogging',
+	openPreviewTarget: 'openPreviewTarget',
+	serverKeepAliveAfterEmbeddedPreviewClose:
+		'serverKeepAliveAfterEmbeddedPreviewClose',
+	notifyOnOpenLooseFile: 'notifyOnOpenLooseFile',
+};
 export const PreviewType: any = {
 	internalPreview: 'internalPreview',
 	externalPreview: 'externalPreview',
 };
-
-export function GetConfig(resource: vscode.Uri): LiveServerConfigItem {
-	const config = vscode.workspace.getConfiguration(
-		SETTINGS_SECTION_ID,
-		resource
-	);
-	return {
-		portNum: config.get<number>('portNum', 3000),
-		showStatusBarItem: config.get<boolean>('showStatusBarItem', true),
-		showServerStatusPopUps: config.get<boolean>(
-			Settings.showServerStatusPopUps,
-			false
-		),
-		autoRefreshPreview: config.get<AutoRefreshPreview>(
-			Settings.autoRefreshPreview,
-			AutoRefreshPreview.onAnyChange
-		),
-		browserPreviewLaunchServerLogging: config.get<boolean>(
-			Settings.browserPreviewLaunchServerLogging,
-			true
-		),
-		openPreviewTarget: config.get<OpenPreviewTarget>(
-			Settings.openPreviewTarget,
-			OpenPreviewTarget.embeddedPreview
-		),
-		serverKeepAliveAfterEmbeddedPreviewClose: config.get<number>(
-			Settings.serverKeepAliveAfterEmbeddedPreviewClose,
-			20
-		),
-		notifyOnOpenLooseFile: config.get<boolean>(
-			Settings.notifyOnOpenLooseFile,
-			true
-		),
-	};
-}
-
-export function GetPreviewType(extensionUri: vscode.Uri): string {
-	if (
-		GetConfig(extensionUri).openPreviewTarget ==
-		OpenPreviewTarget.embeddedPreview
-	) {
-		return PreviewType.internalPreview;
-	} else {
-		return PreviewType.externalPreview;
+export class SettingUtil {
+	public static GetConfig(resource: vscode.Uri): LiveServerConfigItem {
+		const config = vscode.workspace.getConfiguration(
+			SETTINGS_SECTION_ID,
+			resource
+		);
+		return {
+			portNum: config.get<number>('portNum', 3000),
+			showStatusBarItem: config.get<boolean>('showStatusBarItem', true),
+			showServerStatusPopUps: config.get<boolean>(
+				Settings.showServerStatusPopUps,
+				false
+			),
+			autoRefreshPreview: config.get<AutoRefreshPreview>(
+				Settings.autoRefreshPreview,
+				AutoRefreshPreview.onAnyChange
+			),
+			browserPreviewLaunchServerLogging: config.get<boolean>(
+				Settings.browserPreviewLaunchServerLogging,
+				true
+			),
+			openPreviewTarget: config.get<OpenPreviewTarget>(
+				Settings.openPreviewTarget,
+				OpenPreviewTarget.embeddedPreview
+			),
+			serverKeepAliveAfterEmbeddedPreviewClose: config.get<number>(
+				Settings.serverKeepAliveAfterEmbeddedPreviewClose,
+				20
+			),
+			notifyOnOpenLooseFile: config.get<boolean>(
+				Settings.notifyOnOpenLooseFile,
+				true
+			),
+		};
 	}
+	public static GetPreviewType(extensionUri: vscode.Uri): string {
+		if (
+			SettingUtil.GetConfig(extensionUri).openPreviewTarget ==
+			OpenPreviewTarget.embeddedPreview
+		) {
+			return PreviewType.internalPreview;
+		} else {
+			return PreviewType.externalPreview;
+		}
+	}
+
+	public static UpdateSettings<T>(
+		settingSuffix: string,
+		value: T,
+		isGlobal = true
+	): void {
+		vscode.workspace
+			.getConfiguration(SETTINGS_SECTION_ID)
+			.update(settingSuffix, value, isGlobal);
+		SettingUtil.SettingsSavedMessage();
+	}
+
+	public static SettingsSavedMessage(): void {
+		vscode.window
+			.showInformationMessage(
+				'Your selection has been saved in settings.',
+				GO_TO_SETTINGS
+			)
+			.then((selection: vscode.MessageItem | undefined) => {
+				if (selection === GO_TO_SETTINGS) {
+					vscode.commands.executeCommand(
+						'workbench.action.openSettings',
+						SETTINGS_SECTION_ID
+					);
+				}
+			});
+	}
+
+
 }
 
-export function UpdateSettings<T>(
-	settingSuffix: string,
-	value: T,
-	isGlobal = true
-): void {
-	vscode.workspace
-		.getConfiguration(SETTINGS_SECTION_ID)
-		.update(settingSuffix, value, isGlobal);
-	SettingsSavedMessage();
-}
 
-export function SettingsSavedMessage(): void {
-	vscode.window
-		.showInformationMessage(
-			'Your selection has been saved in settings.',
-			GO_TO_SETTINGS
-		)
-		.then((selection: vscode.MessageItem | undefined) => {
-			if (selection === GO_TO_SETTINGS) {
-				vscode.commands.executeCommand(
-					'workbench.action.openSettings',
-					SETTINGS_SECTION_ID
-				);
-			}
-		});
-}
+
+
+
+
+
+

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -43,7 +43,7 @@ export function GetWorkspacePath(): string | undefined {
 }
 
 export function GetActiveFolderPath() {
-	const path = vscode.window.activeTextEditor?.document.uri.fsPath ?? "";
+	const path = vscode.window.activeTextEditor?.document.uri.fsPath ?? '';
 	return GetParentDir(path);
 }
 
@@ -58,7 +58,7 @@ export function GetUnencodedBase(file: string) {
 	return path.basename(unescape(file));
 }
 export function EncodeLooseFilePath(path: string) {
-	return "/" + escape(GetParentDir(path)) + "/" + GetFileName(path);
+	return '/' + escape(GetParentDir(path)) + '/' + GetFileName(path);
 }
 
 export function DecodeLooseFilePath(file: string) {
@@ -73,5 +73,5 @@ export function isFileInjectable(file: string | undefined) {
 	if (!file) {
 		return false;
 	}
-	return (file.endsWith(".html"));
+	return file.endsWith('.html');
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,7 +1,4 @@
-import { pathToFileURL } from 'url';
 import * as vscode from 'vscode';
-import * as fs from 'fs';
-import * as path from 'path';
 
 export function FormatDateTime(date: Date, delimeter = ', '): string {
 	const mm = date.getMonth() + 1;
@@ -34,41 +31,6 @@ export function GetActiveFile(): string | undefined {
 	return vscode.window.activeTextEditor?.document.fileName;
 }
 
-export function GetWorkspace(): vscode.WorkspaceFolder | undefined {
-	return vscode.workspace.workspaceFolders?.[0];
-}
-
-export function GetWorkspacePath(): string | undefined {
-	return GetWorkspace()?.uri.fsPath;
-}
-
-export function GetActiveFolderPath() {
-	const path = vscode.window.activeTextEditor?.document.uri.fsPath ?? '';
-	return GetParentDir(path);
-}
-
-export function GetParentDir(file: string) {
-	return path.dirname(file);
-}
-
-export function GetFileName(file: string) {
-	return path.basename(file);
-}
-export function GetUnencodedBase(file: string) {
-	return path.basename(unescape(file));
-}
-export function EncodeLooseFilePath(path: string) {
-	return '/' + escape(GetParentDir(path)) + '/' + GetFileName(path);
-}
-
-export function DecodeLooseFilePath(file: string) {
-	return unescape(file).substr(1);
-}
-
-export function IsLooseFilePath(file: string) {
-	const absPath = path.join(GetWorkspacePath() ?? '', file);
-	return !fs.existsSync(absPath);
-}
 export function isFileInjectable(file: string | undefined) {
 	if (!file) {
 		return false;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -30,27 +30,14 @@ export function FormatFileSize(bytes: number) {
 	return `${modifiedSize} TB`;
 }
 
-// export function GetRelativeActiveFile(): string {
-// 	const activeFile = GetActiveFile();
-// 	return activeFile ? GetRelativeFile(activeFile) : '';
-// }
-
 export function GetActiveFile(): string | undefined {
 	return vscode.window.activeTextEditor?.document.fileName;
 }
-// export function GetRelativeFile(file: string): string {
-// 	const workspaceFolder = GetWorkspacePath();
-
-// 	if (workspaceFolder && file.startsWith(workspaceFolder)) {
-// 		return file.substr(workspaceFolder.length).replace(/\\/gi, '/');
-// 	} else {
-// 		return '';
-// 	}
-// }
 
 export function GetWorkspace(): vscode.WorkspaceFolder | undefined {
 	return vscode.workspace.workspaceFolders?.[0];
 }
+
 export function GetWorkspacePath(): string | undefined {
 	return GetWorkspace()?.uri.fsPath;
 }
@@ -75,9 +62,7 @@ export function EncodeLooseFilePath(path: string) {
 }
 
 export function DecodeLooseFilePath(file: string) {
-	const parentPath = file.substr(file.indexOf("/")+1,file.lastIndexOf("/"));
-	const fileName = file.substr(file.lastIndexOf("/"),file.length);
-	return path.join(unescape(parentPath),fileName);
+	return unescape(file).substr(1);
 }
 
 export function IsLooseFilePath(file: string) {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -67,7 +67,9 @@ export function GetParentDir(file: string) {
 export function GetFileName(file: string) {
 	return path.basename(file);
 }
-
+export function GetUnencodedBase(file: string) {
+	return path.basename(unescape(file));
+}
 export function EncodeLooseFilePath(path: string) {
 	return "/" + escape(GetParentDir(path)) + "/" + GetFileName(path);
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -48,8 +48,11 @@ export function GetActiveFile(): string | undefined {
 // 	}
 // }
 
+export function GetWorkspace(): vscode.WorkspaceFolder | undefined {
+	return vscode.workspace.workspaceFolders?.[0];
+}
 export function GetWorkspacePath(): string | undefined {
-	return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+	return GetWorkspace()?.uri.fsPath;
 }
 
 export function GetActiveFolderPath() {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,4 +1,7 @@
+import { pathToFileURL } from 'url';
 import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
 
 export function FormatDateTime(date: Date, delimeter = ', '): string {
 	const mm = date.getMonth() + 1;
@@ -27,29 +30,55 @@ export function FormatFileSize(bytes: number) {
 	return `${modifiedSize} TB`;
 }
 
-export function GetRelativeActiveFile(): string {
-	const activeFile = vscode.window.activeTextEditor?.document.fileName;
-	return activeFile ? GetRelativeFile(activeFile) : '';
-}
+// export function GetRelativeActiveFile(): string {
+// 	const activeFile = GetActiveFile();
+// 	return activeFile ? GetRelativeFile(activeFile) : '';
+// }
 
-export function GetRelativeFile(file: string): string {
-	const workspaceFolder = GetWorkspacePath();
-
-	if (workspaceFolder && file.startsWith(workspaceFolder)) {
-		return file.substr(workspaceFolder.length).replace(/\\/gi, '/');
-	} else {
-		return '';
-	}
+export function GetActiveFile(): string | undefined {
+	return vscode.window.activeTextEditor?.document.fileName;
 }
+// export function GetRelativeFile(file: string): string {
+// 	const workspaceFolder = GetWorkspacePath();
+
+// 	if (workspaceFolder && file.startsWith(workspaceFolder)) {
+// 		return file.substr(workspaceFolder.length).replace(/\\/gi, '/');
+// 	} else {
+// 		return '';
+// 	}
+// }
 
 export function GetWorkspacePath(): string | undefined {
-	return GetWorkspace()?.uri.fsPath;
+	return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
 }
 
-export function GetWorkspace() {
-	return vscode.workspace.workspaceFolders?.[0];
+export function GetActiveFolderPath() {
+	const path = vscode.window.activeTextEditor?.document.uri.fsPath ?? "";
+	return GetParentDir(path);
 }
 
+export function GetParentDir(file: string) {
+	return path.dirname(file);
+}
+
+export function GetFileName(file: string) {
+	return path.basename(file);
+}
+
+export function EncodeLooseFilePath(path: string) {
+	return "/" + escape(GetParentDir(path)) + "/" + GetFileName(path);
+}
+
+export function DecodeLooseFilePath(file: string) {
+	const parentPath = file.substr(file.indexOf("/")+1,file.lastIndexOf("/"));
+	const fileName = file.substr(file.lastIndexOf("/"),file.length);
+	return path.join(unescape(parentPath),fileName);
+}
+
+export function IsLooseFilePath(file: string) {
+	const absPath = path.join(GetWorkspacePath() ?? '', file);
+	return !fs.existsSync(absPath);
+}
 export function isFileInjectable(file: string | undefined) {
 	if (!file) {
 		return false;

--- a/test-workspace/page1.html
+++ b/test-workspace/page1.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
 <html>
-	<header>
-		<link href="./styles.css" rel="stylesheet" />
-	</header>
+<header>
+	<link href="./styles.css" rel="stylesheet" />
+</header>
 
-	<body>
-		<p><a href="./">And another link!</a></p>
-		<br />
-	</body>
+<body>
+	<p><a href="./page2.html">And another link!</a></p>
+	<br />
+</body>
+
 </html>

--- a/test-workspace/page1.html
+++ b/test-workspace/page1.html
@@ -5,7 +5,7 @@
 	</header>
 
 	<body>
-		<p><a href="page2.html">And another link!</a></p>
+		<p><a href="./">And another link!</a></p>
 		<br />
 	</body>
 </html>

--- a/test-workspace/page2.html
+++ b/test-workspace/page2.html
@@ -5,7 +5,7 @@
 	</header>
 
 	<body>
-		<p>At the last page! <a href="/">Go back to index</a></p>
+		<p>At the last page! <a href="./">Go back to index</a></p>
 		<br />
 	</body>
 </html>


### PR DESCRIPTION
Allows for previewing files that are not a part of the current workspace. Also works when a workspace is not opened. 
In multi-root workspaces, the first workspace is where the server is hosted, so anything outside of that is considered a non-workspace or "loose file" preview.

[![Image from Gyazo](https://i.gyazo.com/62079d46ece66bea108dc1f8df470249.gif)](https://gyazo.com/62079d46ece66bea108dc1f8df470249)

Loose files are hosted at a specified endpoint where the whole path except the last pathname is escaped. 

![image](https://user-images.githubusercontent.com/31675041/122802778-01579d80-d283-11eb-8178-18a7fbce1fe8.png)

This is to avoid conflicts with existing files in the workspace. Generally, users shouldn't be opening all their files outside workspaces.

By default, the user will be notified on opening a "loose file" preview the first time they do so in a session. They can disable this in settings.

![image](https://user-images.githubusercontent.com/31675041/122804056-a2932380-d284-11eb-86af-fca26e52ed5c.png)
