### PR TITLE
Edited Out-of-workspace Experience

### DIFF
--- a/media/main.js
+++ b/media/main.js
@@ -10,7 +10,8 @@
 	onLoad();
 
 	function onLoad() {
-		updateState(window.location.pathname);
+		// console.log("from init");
+		// updateState(window.location.pathname);
 
 		connection.onerror = (error) => {
 			console.log('WebSocket error: ');
@@ -43,6 +44,7 @@
 	}
 
 	function updateState(pathname) {
+		console.log("updating state " + pathname);
 		vscode.setState({ currentAddress: pathname });
 	}
 
@@ -97,6 +99,7 @@
 					text: message.text,
 				});
 				setURLBar(msgJSON.fullPath.href);
+				console.log("update-path");
 				updateState(msgJSON.pathname);
 				break;
 			}
@@ -118,6 +121,7 @@
 			case 'set-url': {
 				msgJSON = JSON.parse(message.text);
 				setURLBar(msgJSON.fullPath);
+				console.log("set-url");
 				updateState(msgJSON.pathname);
 				break;
 			}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,13 @@
 		"type": "git",
 		"url": "https://github.com/microsoft/vscode-liveserver"
 	},
+	"capabilities": {
+	  "virtualWorkspaces": false,
+	  "untrustedWorkspaces": {
+		"supported": false,
+		"description": "Live Server runs a server to host workspace files."
+	  }
+	},
 	"engines": {
 		"vscode": "^1.56.0"
 	},

--- a/src/editorPreview/browserPreview.ts
+++ b/src/editorPreview/browserPreview.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
 import { HOST, INIT_PANEL_TITLE, OPEN_EXTERNALLY } from '../utils/constants';
 import { Disposable } from '../utils/dispose';
 import { isFileInjectable } from '../utils/utils';
@@ -176,6 +177,8 @@ export class BrowserPreview extends Disposable {
 		if (URLExt.length > 0 && URLExt[0] == '/') {
 			URLExt = URLExt.substring(1);
 		}
+		URLExt = URLExt.replace('\\', '/');
+		URLExt = URLExt.startsWith('/') ? URLExt.substr(1) : URLExt;
 		return `${this._host}/${URLExt}`;
 	}
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -200,6 +200,12 @@ export function activate(context: vscode.ExtensionContext) {
 				if (!PathUtil.PathExistsRelativeToWorkspace(file)) {
 					file = '/';
 				}
+
+				if (file == '/' && !PathUtil.GetWorkspace()) {
+					// root will not show anything, so cannot revive content. Dispose.
+					webviewPanel.dispose();
+					return;
+				}
 				// Reset the webview options so we use latest uri for `localResourceRoots`.
 				webviewPanel.webview.options = getWebviewOptions(context.extensionUri);
 				manager.createOrShowPreview(webviewPanel, file);

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -177,6 +177,10 @@ export class Manager extends Disposable {
 		return this._serverTaskProvider.terminalName == terminalName;
 	}
 
+	public DecodeEndpointPath(file: string) {
+		return this._server.decodeEndpoint(file);
+	}
+
 	public openServer(fromTask = false): boolean {
 		if (!this._server.isRunning) {
 			return this._server.openServer(this._serverPort);
@@ -220,7 +224,7 @@ export class Manager extends Disposable {
 		if (!relative) {
 			if (!this._server.canGetPath(file)) {
 				this.notifyLooseFileOpen();
-				file = PathUtil.EncodeLooseFilePath(file);
+				file = this._server.encodeEndpoint(file);
 			} else {
 				file = this._server.getFileRelativeToWorkspace(file);
 			}

--- a/src/server/serverUtils/endpointManager.ts
+++ b/src/server/serverUtils/endpointManager.ts
@@ -1,0 +1,50 @@
+import { Disposable } from "../../utils/dispose";
+import * as path from 'path';
+import { PathUtil } from "../../utils/pathUtil";
+
+export class EndpointManager extends Disposable {
+    
+    // manages encoding and decoding endpoints
+	private readonly _looseFiles = new Map<
+    /* endpoint: */ string,
+    /* file location: */ string
+    >();
+
+    public encodeLooseFileEndpoint(location: string): string {
+		let i = 0;
+		const parent = PathUtil.GetImmediateParentDir(location);
+        const fullParent = PathUtil.GetParentDir(location);
+		const child = PathUtil.GetFileName(location);
+		let result;
+		let endpoint;
+		do {
+			endpoint = `/endpoint_${parent}_${i}`;
+			result = this._looseFiles.get(endpoint);
+			if (result === fullParent) {
+				return path.join(endpoint, child);
+			}
+			i++;
+		} while (result);
+		this._looseFiles.set(endpoint, fullParent);
+		return path.join(endpoint, child);
+	}
+
+	public getEndpointParent(urlPath: string) {
+		const endpoint = PathUtil.GetFurthestParentDir(urlPath);
+		const parentWithIndex = endpoint.substr(0,endpoint.lastIndexOf("_"));
+		return parentWithIndex.substr(parentWithIndex.indexOf("_")+1);
+	}
+
+	public decodeLooseFileEndpoint(urlPath: string): string | undefined{
+		const endpoint = `/${PathUtil.GetFurthestParentDir(urlPath)}`;
+		const nonEndpoint = urlPath.substr(endpoint.length);
+        const location = this._looseFiles.get(endpoint);
+
+        if (location) {
+            return path.join(location, nonEndpoint);
+        } else {
+            return undefined;
+        }
+	}
+
+}

--- a/src/utils/pathUtil.ts
+++ b/src/utils/pathUtil.ts
@@ -3,6 +3,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 export class PathUtil {
+	public static pathSepRegex = /(?:\\|\/)+/;
+
 	public static GetWorkspace(): vscode.WorkspaceFolder | undefined {
 		return vscode.workspace.workspaceFolders?.[0];
 	}
@@ -20,21 +22,31 @@ export class PathUtil {
 		return path.dirname(file);
 	}
 
+	public static GetImmediateParentDir(file: string) {
+		return PathUtil.GetParentDir(file).split(PathUtil.pathSepRegex).pop();
+	}
+
+	public static GetFurthestParentDir(file: string) {
+		const paths = file.split(PathUtil.pathSepRegex);
+		const result = PathUtil.GetFirstNonEmptyElem(paths);
+		return result ?? '';
+	}
+
+	public static PathExistsRelativeToWorkspace(file: string) {
+		const fullPath = path.join(PathUtil.GetWorkspacePath() ?? '', file);
+		return fs.existsSync(fullPath);
+	}
+
+	public static GetFirstNonEmptyElem(paths: string[]) {
+		for (const i in paths) {
+			if (paths[i].length) {
+				return paths[i];
+			}
+		}
+		return undefined;
+	}
 	public static GetFileName(file: string) {
 		return path.basename(file);
-	}
-
-	public static EncodeLooseFilePath(path: string) {
-		return (
-			'/' +
-			escape(PathUtil.GetParentDir(path)) +
-			'/' +
-			PathUtil.GetFileName(path)
-		);
-	}
-
-	public static DecodeLooseFilePath(file: string) {
-		return unescape(file).substr(1);
 	}
 
 	public static IsLooseFilePath(file: string) {


### PR DESCRIPTION
Edited endpoints for non-workspace files to:
1. Be shorter.
2. Not reveal any absolute path info.

Since encoding endpoints requires historical data on opened files, reviving webviews on non-workspace previews will just redirect to index.
Also add capabilities in `package.json`


Endpoint example when immediate parent to hosted file is `statichtml_proj`:
![image](https://user-images.githubusercontent.com/31675041/123301113-838ccf80-d4d8-11eb-8a21-ed7a05e34bcb.png)
