### PR TITLE
Multi-root Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Notes about workspace-less extension use:
 ### Multi-root Support
 When using a multi-root workspace, use `Live Preview: Select Default Workspace for Server` to select a default workspace for the server root. The selection will be saved in your workspace setting. Alternatively, you can also directly assign a path to the `LivePreview.serverWorkspace` setting.
 
+Files outside of the default server workspace will just be treated as non-workspace when previewing.
+
 ## Prerequisites
 To use this extension, you must have [Node JS v14+](https://nodejs.org/en/download/). 
 ## Running the extension

--- a/README.md
+++ b/README.md
@@ -47,7 +47,11 @@ No workspace? No problem! For a quick preview of your file, the server can also 
 
 Notes about workspace-less extension use:
 - Linked files for these pages may not be correct if they are relative to a specific root (e.g. a project root). 
-- Tasks do not work outside of a workspace, so a server will just launch in the background upon external preview when outside of a workspace. You can use the `Force Stop Live Preview Server` command to kill the server in this case.
+- Tasks do not work outside of a workspace, so a server will just launch in the background upon external preview when outside of a workspace. You can use the `Live Preview: Force Stop Server` command to kill the server in this case.
+
+### Multi-root Support
+When using a multi-root workspace, use `Live Preview: Select Default Workspace for Server` to select a default workspace for the server root. The selection will be saved in your workspace setting. Alternatively, you can also directly assign a path to the `LivePreview.serverWorkspace` setting.
+
 ## Prerequisites
 To use this extension, you must have [Node JS v14+](https://nodejs.org/en/download/). 
 ## Running the extension
@@ -65,11 +69,11 @@ Q. What does the `"Previewing a file that is not a child of the server root. To 
 A. Either:
 - You have no workspace open and opened a preview.
 - You opened a preview for a file that is not normally part of your workspace.
-- You are in a multi-root workspace and opened a file that is not a child of your first workspace root.
+- You are in a multi-root workspace and opened a file that is not a child of your selected default server workspace (or have not reloaded the window after changing your setting).
 
 Why does this happen? 
 
-The server is hosted from the root of the workspace that the user opens (or in a multi-root case, the first workspace that the user opens). Files outside of this can be previewed, but some file paths (such as a link to the root) may not go to the right place. **If you are working on a web project, it is advised that you open a workspace at the root of the project.**
+The server is hosted from the root of the workspace that the user opens (or in a multi-root case, the selected default workspace). Files outside of this can be previewed, but some file paths (such as a link to the root) may not go to the right place. **If you are working on a web project, it is advised that you open a workspace at the root of the project.**
 
 ## Issue Tracking
 - [May Iteration](https://github.com/microsoft/vscode/issues/124607)

--- a/media/main.js
+++ b/media/main.js
@@ -97,6 +97,9 @@
 				});
 				setURLBar(msgJSON.path.href);
 				updateState(msgJSON.path.pathname);
+
+				// remove link preview box from last page.
+				document.getElementById('link-preview').hidden = true;
 				break;
 			}
 			// from child iframe

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "live-server",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -42,33 +42,37 @@
 	"contributes": {
 		"commands": [
 			{
+				"command": "LivePreview.config.selectWorkspace",
+				"title": "Live Preview: Select Default Workspace for Server"
+			},
+			{
 				"command": "LivePreview.start.preview.atIndex",
-				"title": "Show Web Preview at Index Page"
+				"title": "Live Preview: Show Preview at Index Page"
 			},
 			{
 				"command": "LivePreview.start.preview.atFile",
-				"title": "Show Preview",
+				"title": "Live Preview: Show Preview",
 				"icon": "$(open-preview)"
 			},
 			{
 				"command": "LivePreview.start.externalPreview.atIndex",
-				"title": "Show Web Preview at Index (External Browser)"
+				"title": "Live Preview: Show Preview at Index (External Browser)"
 			},
 			{
 				"command": "LivePreview.start.internalPreview.atIndex",
-				"title": "Show Web Preview at Index (Internal Browser)"
+				"title": "Live Preview: Show Preview at Index (Internal Browser)"
 			},
 			{
 				"command": "LivePreview.start.externalPreview.atFile",
-				"title": "Show Web Preview (External Browser)"
+				"title": "Live Preview: Show Preview (External Browser)"
 			},
 			{
 				"command": "LivePreview.start.internalPreview.atFile",
-				"title": "Show Web Preview (Internal Browser)"
+				"title": "Live Preview: Show Preview (Internal Browser)"
 			},
 			{
 				"command": "LivePreview.end",
-				"title": "Force Stop Live Preview Server"
+				"title": "Live Preview: Force Stop Server"
 			}
 		],
 		"menus": {
@@ -157,6 +161,17 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Whether to notify the user when opening a preview for a file that is not part of the currently opened workspace (or the workspace where the server is hosted)."
+				},
+				"LivePreview.serverWorkspace": {
+					"type": "string",
+					"scope": "resource",
+					"default": "",
+					"description": "For multi-root workspaces: which workspace path should be used as the server root. Leave blank to use first workspace. Reload window to use changed setting."
+				},
+				"LivePreview.showWarningOnMultiRootOpen": {
+					"type": "boolean",
+					"default": true,
+					"description": "Whether or not to warn the user upon opening a multi-root preview with an undefined default server workspace."
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "live-server",
 	"displayName": "Live Preview - Insiders",
 	"description": "Hosts a local server in your workspace for you to preview your webpages.",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"preview": true,
 	"aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
 	"publisher": "ms-vscode",
@@ -87,7 +87,7 @@
 				{
 					"command": "LivePreview.start.preview.atFile",
 					"when": "resourceLangId == html",
-					"group": "1_liveserver"
+					"group": "navigation"
 				}
 			],
 			"commandPalette": [

--- a/src/editorPreview/browserPreview.ts
+++ b/src/editorPreview/browserPreview.ts
@@ -279,7 +279,7 @@ export class BrowserPreview extends Disposable {
 				</div>
 				
 			</div>
-			<div id="link-preview">an example link</div>
+			<div id="link-preview"></div>
 				<script nonce="${nonce}">
 					const WS_URL= "${wsURL}";
 				</script>

--- a/src/editorPreview/browserPreview.ts
+++ b/src/editorPreview/browserPreview.ts
@@ -5,6 +5,7 @@ import { isFileInjectable } from '../utils/utils';
 import { PathUtil } from '../utils/pathUtil';
 import { PageHistory, NavEditCommands } from './pageHistoryTracker';
 import TelemetryReporter from 'vscode-extension-telemetry';
+import { WorkspaceManager } from '../multiRootManagers/workspaceManager';
 
 export class BrowserPreview extends Disposable {
 	public static readonly viewType = 'browserPreview';
@@ -38,7 +39,8 @@ export class BrowserPreview extends Disposable {
 		private _port: number,
 		private _wsPort: number,
 		initialFile: string,
-		private readonly _reporter: TelemetryReporter
+		private readonly _reporter: TelemetryReporter,
+		private readonly _workspaceManager: WorkspaceManager
 	) {
 		super();
 
@@ -362,7 +364,7 @@ export class BrowserPreview extends Disposable {
 	private setPanelTitle(title = '', pathname = 'Preview'): void {
 		if (title == '') {
 			if (pathname.length > 0 && pathname[0] == '/') {
-				if (PathUtil.IsLooseFilePath(pathname)) {
+				if (this._workspaceManager.isLooseFilePath(pathname)) {
 					this._panel.title = PathUtil.GetFileName(pathname);
 				} else {
 					this._panel.title = pathname.substr(1);

--- a/src/editorPreview/pageHistoryTracker.ts
+++ b/src/editorPreview/pageHistoryTracker.ts
@@ -80,6 +80,7 @@ export class PageHistory extends Disposable {
 	}
 
 	public addHistory(address: string): NavResponse | undefined {
+		address = address.replace(/\\/g, '/');
 		const action = new Array<NavEditCommands>();
 		if (
 			this._backstep < this._history.length &&

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,6 @@ import { BrowserPreview } from './editorPreview/browserPreview';
 import { getWebviewOptions, Manager } from './manager';
 import { EXTENSION_ID } from './utils/constants';
 import { SETTINGS_SECTION_ID, SettingUtil } from './utils/settingsUtil';
-import { PathUtil } from './utils/pathUtil';
 import { GetActiveFile } from './utils/utils';
 
 let reporter: TelemetryReporter;
@@ -40,6 +39,15 @@ export function activate(context: vscode.ExtensionContext) {
 					`${SETTINGS_SECTION_ID}.start.${previewType}.atFile`,
 					file
 				);
+			}
+		)
+	);
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand(
+			`${SETTINGS_SECTION_ID}.config.selectWorkspace`,
+			() => {
+				SettingUtil.UpdateWorkspacePath();
 			}
 		)
 	);
@@ -195,11 +203,11 @@ export function activate(context: vscode.ExtensionContext) {
 			) {
 				let file = state.currentAddress ?? '/';
 
-				if (!PathUtil.PathExistsRelativeToWorkspace(file)) {
+				if (!manager.pathExistsRelativeToWorkspace(file)) {
 					file = '/';
 				}
 
-				if (file == '/' && !PathUtil.GetWorkspace()) {
+				if (file == '/' && !manager.workspace) {
 					// root will not show anything, so cannot revive content. Dispose.
 					webviewPanel.dispose();
 					return;

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -216,6 +216,8 @@ export class Manager extends Disposable {
 				this._workspaceManager.hasNullPathSetting()
 			) {
 				this.notifyMultiRootOpen();
+			} else if (this._workspaceManager.invalidPath) {
+				this.warnAboutBadPath();
 			}
 			return this._server.openServer(this._serverPort);
 		} else if (fromTask) {
@@ -299,7 +301,7 @@ export class Manager extends Disposable {
 		) {
 			vscode.window
 				.showWarningMessage(
-					`There is no set default workspace to use in your multi-root workspace, so the first listed workspace (${this._workspaceManager.workspacePathname}) will be used.`,
+					`There is no set default server workspace to use in your multi-root workspace, so the first workspace (${this._workspaceManager.workspacePathname}) will be used.`,
 					DONT_SHOW_AGAIN,
 					CONFIG_MULTIROOT
 				)
@@ -317,6 +319,21 @@ export class Manager extends Disposable {
 				});
 		}
 		this._notifiedAboutMultiRoot = true;
+	}
+	private warnAboutBadPath() {
+		const optMsg = this.workspace ? `Using ${this.workspace?.name} instead.` : ``;
+		vscode.window
+		.showWarningMessage(
+			`Cannot use workspace at ${this._workspaceManager.settingsWorkspace} for server.${optMsg}`,
+			CONFIG_MULTIROOT
+		)
+		.then((selection: vscode.MessageItem | undefined) => {
+			if (selection == CONFIG_MULTIROOT) {
+				vscode.commands.executeCommand(
+					`${SETTINGS_SECTION_ID}.config.selectWorkspace`
+				);
+			}
+		});
 	}
 	private startEmbeddedPreview(panel: vscode.WebviewPanel, file: string) {
 		if (this._currentTimeout) {

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -2,8 +2,12 @@ import * as vscode from 'vscode';
 import { BrowserPreview } from './editorPreview/browserPreview';
 import { Disposable } from './utils/dispose';
 import { Server } from './server/serverManager';
-import { INIT_PANEL_TITLE, HOST, DONT_SHOW_AGAIN } from './utils/constants';
-import { PathUtil } from './utils/pathUtil';
+import {
+	INIT_PANEL_TITLE,
+	HOST,
+	DONT_SHOW_AGAIN,
+	CONFIG_MULTIROOT,
+} from './utils/constants';
 import {
 	ServerStartedStatus,
 	ServerTaskProvider,
@@ -14,7 +18,8 @@ import {
 	SettingUtil,
 } from './utils/settingsUtil';
 import TelemetryReporter from 'vscode-extension-telemetry';
-import { EndpointManager } from './server/serverUtils/endpointManager';
+import { EndpointManager } from './multiRootManagers/endpointManager';
+import { WorkspaceManager } from './multiRootManagers/workspaceManager';
 
 export interface serverMsg {
 	method: string;
@@ -29,7 +34,9 @@ export class Manager extends Disposable {
 	private _previewActive = false;
 	private _currentTimeout: NodeJS.Timeout | undefined;
 	private _notifiedAboutLooseFiles = false;
-	private _endpointManager: any;
+	private _endpointManager: EndpointManager;
+	private _workspaceManager: WorkspaceManager;
+	private _notifiedAboutMultiRoot = false;
 	// always leave off at previous port numbers to avoid retrying on many busy ports
 
 	private get _serverPort() {
@@ -44,21 +51,34 @@ export class Manager extends Disposable {
 	private set _serverWSPort(portNum: number) {
 		this._server.ws_port = portNum;
 	}
+	public get workspace(): vscode.WorkspaceFolder | undefined {
+		return this._workspaceManager.workspace;
+	}
 	constructor(
 		private readonly _extensionUri: vscode.Uri,
 		private readonly _reporter: TelemetryReporter
 	) {
 		super();
 		this._endpointManager = this._register(new EndpointManager());
+		this._workspaceManager = this._register(
+			new WorkspaceManager(_extensionUri)
+		);
+
 		this._server = this._register(
-			new Server(_extensionUri, this._endpointManager, _reporter)
+			new Server(
+				_extensionUri,
+				this._endpointManager,
+				_reporter,
+				this._workspaceManager
+			)
 		);
 		this._serverPort = SettingUtil.GetConfig(_extensionUri).portNumber;
 		this._serverWSPort = SettingUtil.GetConfig(_extensionUri).portNumber + 1;
 
 		this._serverTaskProvider = new ServerTaskProvider(
 			this._reporter,
-			this._endpointManager
+			this._endpointManager,
+			this._workspaceManager
 		);
 		this._register(
 			vscode.tasks.registerTaskProvider(
@@ -160,7 +180,7 @@ export class Manager extends Disposable {
 	}
 
 	public showPreviewInBrowser(file = '/', relative = true) {
-		if (PathUtil.GetWorkspace()) {
+		if (this.workspace) {
 			if (!this._serverTaskProvider.isRunning) {
 				this._serverTaskProvider.extRunTask(
 					SettingUtil.GetConfig(this._extensionUri)
@@ -191,6 +211,12 @@ export class Manager extends Disposable {
 
 	public openServer(fromTask = false): boolean {
 		if (!this._server.isRunning) {
+			if (
+				this._workspaceManager.numPaths > 1 &&
+				this._workspaceManager.hasNullPathSetting()
+			) {
+				this.notifyMultiRootOpen();
+			}
 			return this._server.openServer(this._serverPort);
 		} else if (fromTask) {
 			this._serverTaskProvider.serverStarted(
@@ -228,6 +254,9 @@ export class Manager extends Disposable {
 		return this._server.canGetPath(file);
 	}
 
+	public pathExistsRelativeToWorkspace(file: string) {
+		return this._workspaceManager.pathExistsRelativeToWorkspace(file);
+	}
 	private transformNonRelativeFile(relative: boolean, file: string): string {
 		if (!relative) {
 			if (!this._server.canGetPath(file)) {
@@ -263,18 +292,44 @@ export class Manager extends Disposable {
 		this._notifiedAboutLooseFiles = true;
 	}
 
+	private notifyMultiRootOpen() {
+		if (
+			!this._notifiedAboutMultiRoot &&
+			SettingUtil.GetConfig(this._extensionUri).showWarningOnMultiRootOpen
+		) {
+			vscode.window
+				.showWarningMessage(
+					`There is no set default workspace to use in your multi-root workspace, so the first listed workspace (${this._workspaceManager.workspacePathname}) will be used.`,
+					DONT_SHOW_AGAIN,
+					CONFIG_MULTIROOT
+				)
+				.then((selection: vscode.MessageItem | undefined) => {
+					if (selection == DONT_SHOW_AGAIN) {
+						SettingUtil.UpdateSettings(
+							Settings.showWarningOnMultiRootOpen,
+							false
+						);
+					} else if (selection == CONFIG_MULTIROOT) {
+						vscode.commands.executeCommand(
+							`${SETTINGS_SECTION_ID}.config.selectWorkspace`
+						);
+					}
+				});
+		}
+		this._notifiedAboutMultiRoot = true;
+	}
 	private startEmbeddedPreview(panel: vscode.WebviewPanel, file: string) {
 		if (this._currentTimeout) {
 			clearTimeout(this._currentTimeout);
 		}
-
 		this.currentPanel = new BrowserPreview(
 			panel,
 			this._extensionUri,
 			this._serverPort,
 			this._serverWSPort,
 			file,
-			this._reporter
+			this._reporter,
+			this._workspaceManager
 		);
 
 		this._previewActive = true;

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -321,19 +321,21 @@ export class Manager extends Disposable {
 		this._notifiedAboutMultiRoot = true;
 	}
 	private warnAboutBadPath() {
-		const optMsg = this.workspace ? `Using ${this.workspace?.name} instead.` : ``;
+		const optMsg = this.workspace
+			? `Using ${this.workspace?.name} instead.`
+			: ``;
 		vscode.window
-		.showWarningMessage(
-			`Cannot use workspace at ${this._workspaceManager.settingsWorkspace} for server.${optMsg}`,
-			CONFIG_MULTIROOT
-		)
-		.then((selection: vscode.MessageItem | undefined) => {
-			if (selection == CONFIG_MULTIROOT) {
-				vscode.commands.executeCommand(
-					`${SETTINGS_SECTION_ID}.config.selectWorkspace`
-				);
-			}
-		});
+			.showWarningMessage(
+				`Cannot use workspace at ${this._workspaceManager.settingsWorkspace} for server.${optMsg}`,
+				CONFIG_MULTIROOT
+			)
+			.then((selection: vscode.MessageItem | undefined) => {
+				if (selection == CONFIG_MULTIROOT) {
+					vscode.commands.executeCommand(
+						`${SETTINGS_SECTION_ID}.config.selectWorkspace`
+					);
+				}
+			});
 	}
 	private startEmbeddedPreview(panel: vscode.WebviewPanel, file: string) {
 		if (this._currentTimeout) {

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -326,7 +326,7 @@ export class Manager extends Disposable {
 			: ``;
 		vscode.window
 			.showWarningMessage(
-				`Cannot use workspace at ${this._workspaceManager.settingsWorkspace} for server.${optMsg}`,
+				`Cannot use workspace at ${this._workspaceManager.settingsWorkspace} for server. ${optMsg}`,
 				CONFIG_MULTIROOT
 			)
 			.then((selection: vscode.MessageItem | undefined) => {

--- a/src/multiRootManagers/endpointManager.ts
+++ b/src/multiRootManagers/endpointManager.ts
@@ -1,6 +1,6 @@
-import { Disposable } from '../../utils/dispose';
+import { Disposable } from '../utils/dispose';
 import * as path from 'path';
-import { PathUtil } from '../../utils/pathUtil';
+import { PathUtil } from '../utils/pathUtil';
 
 export class EndpointManager extends Disposable {
 	// manages encoding and decoding endpoints

--- a/src/multiRootManagers/workspaceManager.ts
+++ b/src/multiRootManagers/workspaceManager.ts
@@ -1,0 +1,85 @@
+import { Disposable } from '../utils/dispose';
+import { SETTINGS_SECTION_ID, SettingUtil } from '../utils/settingsUtil';
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+import { CONFIG_MULTIROOT } from '../utils/constants';
+
+export class WorkspaceManager extends Disposable {
+	private readonly _workspace: vscode.WorkspaceFolder | undefined;
+	private _settingsWorkspace = '';
+	constructor(private readonly _extensionUri: vscode.Uri) {
+		super();
+		if (this.numPaths > 1) {
+			this._settingsWorkspace = SettingUtil.GetConfig(
+				this._extensionUri
+			).serverWorkspace;
+			this._workspace = this.getWorkspaceFromPath(this._settingsWorkspace);
+		} else {
+			this._workspace = this.firstListedWorkspace;
+		}
+	}
+
+	public get workspace(): vscode.WorkspaceFolder | undefined {
+		return this._workspace;
+	}
+
+	public get workspacePath(): string | undefined {
+		return this.workspace?.uri.fsPath;
+	}
+
+	public get workspacePathname(): string {
+		return this.workspace?.name ?? '';
+	}
+
+	public get numPaths(): number {
+		return vscode.workspace.workspaceFolders?.length ?? 0;
+	}
+
+	public pathExistsRelativeToWorkspace(file: string) {
+		const fullPath = path.join(this.workspacePath ?? '', file);
+		return fs.existsSync(fullPath);
+	}
+
+	public isLooseFilePath(file: string) {
+		const absPath = path.join(this.workspacePath ?? '', file);
+		return !fs.existsSync(absPath);
+	}
+
+	public hasNullPathSetting() {
+		return this._settingsWorkspace == '';
+	}
+	private get firstListedWorkspace() {
+		return vscode.workspace.workspaceFolders?.[0];
+	}
+
+	private getWorkspaceFromPath(workspaceName: string) {
+		const workspaceFolders = vscode.workspace.workspaceFolders;
+		if (!workspaceFolders || workspaceFolders.length == 0) {
+			return undefined;
+		} else if (workspaceName == '') {
+			return this.firstListedWorkspace;
+		}
+
+		if (workspaceFolders) {
+			for (let i = 0; i < workspaceFolders.length; i++) {
+				if (workspaceFolders[i].uri.fsPath == workspaceName) {
+					return workspaceFolders[i];
+				}
+			}
+		}
+		vscode.window
+			.showWarningMessage(
+				`Cannot use workspace at ${workspaceName} for server. Using ${this.firstListedWorkspace?.name} instead.`,
+				CONFIG_MULTIROOT
+			)
+			.then((selection: vscode.MessageItem | undefined) => {
+				if (selection == CONFIG_MULTIROOT) {
+					vscode.commands.executeCommand(
+						`${SETTINGS_SECTION_ID}.config.selectWorkspace`
+					);
+				}
+			});
+		return this.firstListedWorkspace;
+	}
+}

--- a/src/multiRootManagers/workspaceManager.ts
+++ b/src/multiRootManagers/workspaceManager.ts
@@ -7,14 +7,15 @@ import { CONFIG_MULTIROOT } from '../utils/constants';
 
 export class WorkspaceManager extends Disposable {
 	private readonly _workspace: vscode.WorkspaceFolder | undefined;
-	private _settingsWorkspace = '';
+	public settingsWorkspace = '';
+	public invalidPath = false;
 	constructor(private readonly _extensionUri: vscode.Uri) {
 		super();
 		if (this.numPaths > 1) {
-			this._settingsWorkspace = SettingUtil.GetConfig(
+			this.settingsWorkspace = SettingUtil.GetConfig(
 				this._extensionUri
 			).serverWorkspace;
-			this._workspace = this.getWorkspaceFromPath(this._settingsWorkspace);
+			this._workspace = this.getWorkspaceFromPath(this.settingsWorkspace);
 		} else {
 			this._workspace = this.firstListedWorkspace;
 		}
@@ -47,7 +48,7 @@ export class WorkspaceManager extends Disposable {
 	}
 
 	public hasNullPathSetting() {
-		return this._settingsWorkspace == '';
+		return this.settingsWorkspace == '';
 	}
 	private get firstListedWorkspace() {
 		return vscode.workspace.workspaceFolders?.[0];
@@ -68,18 +69,7 @@ export class WorkspaceManager extends Disposable {
 				}
 			}
 		}
-		vscode.window
-			.showWarningMessage(
-				`Cannot use workspace at ${workspaceName} for server. Using ${this.firstListedWorkspace?.name} instead.`,
-				CONFIG_MULTIROOT
-			)
-			.then((selection: vscode.MessageItem | undefined) => {
-				if (selection == CONFIG_MULTIROOT) {
-					vscode.commands.executeCommand(
-						`${SETTINGS_SECTION_ID}.config.selectWorkspace`
-					);
-				}
-			});
+		this.invalidPath = true;
 		return this.firstListedWorkspace;
 	}
 }

--- a/src/server/httpServer.ts
+++ b/src/server/httpServer.ts
@@ -9,7 +9,7 @@ import { HOST } from '../utils/constants';
 import { serverMsg } from '../manager';
 import { isFileInjectable } from '../utils/utils';
 import TelemetryReporter from 'vscode-extension-telemetry';
-import { EndpointManager } from './serverUtils/endpointManager';
+import { EndpointManager } from '../multiRootManagers/endpointManager';
 
 export class HttpServer extends Disposable {
 	private _server: any;

--- a/src/server/serverManager.ts
+++ b/src/server/serverManager.ts
@@ -12,7 +12,8 @@ import { DONT_SHOW_AGAIN } from '../utils/constants';
 import { serverMsg } from '../manager';
 import { PathUtil } from '../utils/pathUtil';
 import TelemetryReporter from 'vscode-extension-telemetry';
-import { EndpointManager } from './serverUtils/endpointManager';
+import { EndpointManager } from '../multiRootManagers/endpointManager';
+import { WorkspaceManager } from '../multiRootManagers/workspaceManager';
 
 export interface PortInfo {
 	port?: number;
@@ -28,16 +29,17 @@ export class Server extends Disposable {
 
 	constructor(
 		private readonly _extensionUri: vscode.Uri,
-		private readonly _endpointManager: EndpointManager,
-		reporter: TelemetryReporter
+		endpointManager: EndpointManager,
+		reporter: TelemetryReporter,
+		workspaceManager: WorkspaceManager
 	) {
 		super();
 		this._httpServer = this._register(
-			new HttpServer(_extensionUri, reporter, _endpointManager)
+			new HttpServer(_extensionUri, reporter, endpointManager)
 		);
-		this._wsServer = this._register(new WSServer(reporter, _endpointManager));
+		this._wsServer = this._register(new WSServer(reporter, endpointManager));
 		this._statusBar = this._register(new StatusBarNotifier(_extensionUri));
-		this._workspacePath = PathUtil.GetWorkspacePath();
+		this._workspacePath = workspaceManager.workspacePath;
 
 		this._register(
 			vscode.workspace.onDidChangeTextDocument((e) => {

--- a/src/server/serverUtils/contentLoader.ts
+++ b/src/server/serverUtils/contentLoader.ts
@@ -69,7 +69,7 @@ export class ContentLoader extends Disposable {
 		const dirEntries = new Array<IndexDirEntry>();
 
 		if (relativePath != '/') {
-			dirEntries.push({ LinkSrc: '/../', LinkName: '..', DateTime: '' });
+			dirEntries.push({ LinkSrc: '..', LinkName: '..', DateTime: '' });
 		}
 
 		for (const i in childFiles) {

--- a/src/server/wsServer.ts
+++ b/src/server/wsServer.ts
@@ -106,13 +106,15 @@ export class WSServer extends Disposable {
 		urlString: string
 	): { injectable: boolean; pathname: string } {
 		const url = new URL(urlString);
-		const absolutePath = path.join(basePath, url.pathname);
+		let absolutePath = path.join(basePath, url.pathname);
 
 		if (!fs.existsSync(absolutePath)) {
 			const decodedLocation =
 				this._endpointManager.decodeLooseFileEndpoint(absolutePath);
 			if (!decodedLocation || !fs.existsSync(decodedLocation)) {
 				return { injectable: false, pathname: url.pathname };
+			} else {
+				absolutePath = decodedLocation;
 			}
 		}
 

--- a/src/server/wsServer.ts
+++ b/src/server/wsServer.ts
@@ -6,7 +6,7 @@ import { URL } from 'url';
 import { Disposable } from '../utils/dispose';
 import { isFileInjectable } from '../utils/utils';
 import TelemetryReporter from 'vscode-extension-telemetry';
-import { EndpointManager } from './serverUtils/endpointManager';
+import { EndpointManager } from '../multiRootManagers/endpointManager';
 
 export class WSServer extends Disposable {
 	private _wss: WebSocket.Server | undefined;

--- a/src/task/serverTaskLinkProvider.ts
+++ b/src/task/serverTaskLinkProvider.ts
@@ -2,9 +2,10 @@ import { Disposable } from '../utils/dispose';
 import * as vscode from 'vscode';
 import TelemetryReporter from 'vscode-extension-telemetry';
 import { PathUtil } from '../utils/pathUtil';
-import { EndpointManager } from '../server/serverUtils/endpointManager';
+import { EndpointManager } from '../multiRootManagers/endpointManager';
 import { HOST } from '../utils/constants';
 import { URL } from 'url';
+import { WorkspaceManager } from '../multiRootManagers/workspaceManager';
 export class serverTaskLinkProvider
 	extends Disposable
 	implements vscode.TerminalLinkProvider
@@ -14,7 +15,8 @@ export class serverTaskLinkProvider
 	constructor(
 		terminalName: string,
 		private readonly _reporter: TelemetryReporter,
-		private readonly _endpointManager: EndpointManager
+		private readonly _endpointManager: EndpointManager,
+		private readonly _workspaceManager: WorkspaceManager
 	) {
 		super();
 		this.terminalName = terminalName;
@@ -87,9 +89,10 @@ export class serverTaskLinkProvider
 	}
 
 	private openRelativeLinkInWorkspace(file: string, isDir: boolean) {
-		const isWorkspaceFile = PathUtil.PathExistsRelativeToWorkspace(file);
+		const isWorkspaceFile =
+			this._workspaceManager.pathExistsRelativeToWorkspace(file);
 		const fullPath = isWorkspaceFile
-			? PathUtil.GetWorkspace()?.uri + file
+			? this._workspaceManager.workspace?.uri + file
 			: 'file:///' + this._endpointManager.decodeLooseFileEndpoint(file);
 
 		const uri = vscode.Uri.parse(fullPath);

--- a/src/task/serverTaskProvider.ts
+++ b/src/task/serverTaskProvider.ts
@@ -1,7 +1,8 @@
 import * as vscode from 'vscode';
 import TelemetryReporter from 'vscode-extension-telemetry';
 import { serverMsg } from '../manager';
-import { EndpointManager } from '../server/serverUtils/endpointManager';
+import { EndpointManager } from '../multiRootManagers/endpointManager';
+import { WorkspaceManager } from '../multiRootManagers/workspaceManager';
 import { Disposable } from '../utils/dispose';
 import { PathUtil } from '../utils/pathUtil';
 import { serverTaskLinkProvider } from './serverTaskLinkProvider';
@@ -34,11 +35,17 @@ export class ServerTaskProvider
 
 	constructor(
 		private readonly _reporter: TelemetryReporter,
-		endpointManager: EndpointManager
+		endpointManager: EndpointManager,
+		private readonly _workspaceManager: WorkspaceManager
 	) {
 		super();
 		this._terminalLinkProvider = this._register(
-			new serverTaskLinkProvider('', _reporter, endpointManager)
+			new serverTaskLinkProvider(
+				'',
+				_reporter,
+				endpointManager,
+				_workspaceManager
+			)
 		);
 	}
 
@@ -151,7 +158,7 @@ export class ServerTaskProvider
 		if (this._terminal && this._terminal.running) {
 			return new vscode.Task(
 				definition,
-				PathUtil.GetWorkspace() ?? vscode.TaskScope.Workspace,
+				this._workspaceManager.workspace ?? vscode.TaskScope.Workspace,
 				termName,
 				ServerTaskProvider.CustomBuildScriptType,
 				undefined

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -8,6 +8,10 @@ export const GO_TO_SETTINGS: vscode.MessageItem = {
 	title: 'Go To Settings',
 };
 
+export const RELOAD_WINDOW: vscode.MessageItem = {
+	title: 'Reload Window',
+};
+
 export const DONT_SHOW_AGAIN: vscode.MessageItem = {
 	title: "Don't Show Again",
 };
@@ -15,6 +19,11 @@ export const DONT_SHOW_AGAIN: vscode.MessageItem = {
 export const OPEN_EXTERNALLY: vscode.MessageItem = {
 	title: 'Open Externally',
 };
+
+export const CONFIG_MULTIROOT: vscode.MessageItem = {
+	title: 'Configure Default Server Workspace',
+};
+
 export const HOST = '127.0.0.1';
 
 export const EXTENSION_ID = 'ms-vscode.live-server';

--- a/src/utils/pathUtil.ts
+++ b/src/utils/pathUtil.ts
@@ -1,17 +1,16 @@
 import * as vscode from 'vscode';
-import * as fs from 'fs';
 import * as path from 'path';
 
 export class PathUtil {
 	public static pathSepRegex = /(?:\\|\/)+/;
 
-	public static GetWorkspace(): vscode.WorkspaceFolder | undefined {
-		return vscode.workspace.workspaceFolders?.[0];
-	}
+	// public static GetWorkspace(): vscode.WorkspaceFolder | undefined {
+	// 	return vscode.workspace.workspaceFolders?.[0];
+	// }
 
-	public static GetWorkspacePath(): string | undefined {
-		return PathUtil.GetWorkspace()?.uri.fsPath;
-	}
+	// public static GetWorkspacePath(): string | undefined {
+	// 	return PathUtil.GetWorkspace()?.uri.fsPath;
+	// }
 
 	public static GetActiveFolderPath() {
 		const path = vscode.window.activeTextEditor?.document.uri.fsPath ?? '';
@@ -32,10 +31,10 @@ export class PathUtil {
 		return result ?? '';
 	}
 
-	public static PathExistsRelativeToWorkspace(file: string) {
-		const fullPath = path.join(PathUtil.GetWorkspacePath() ?? '', file);
-		return fs.existsSync(fullPath);
-	}
+	// public static PathExistsRelativeToWorkspace(file: string) {
+	// 	const fullPath = path.join(PathUtil.GetWorkspacePath() ?? '', file);
+	// 	return fs.existsSync(fullPath);
+	// }
 
 	public static GetFirstNonEmptyElem(paths: string[]) {
 		for (const i in paths) {
@@ -49,8 +48,8 @@ export class PathUtil {
 		return path.basename(file);
 	}
 
-	public static IsLooseFilePath(file: string) {
-		const absPath = path.join(PathUtil.GetWorkspacePath() ?? '', file);
-		return !fs.existsSync(absPath);
-	}
+	// public static IsLooseFilePath(file: string) {
+	// 	const absPath = path.join(PathUtil.GetWorkspacePath() ?? '', file);
+	// 	return !fs.existsSync(absPath);
+	// }
 }

--- a/src/utils/pathUtil.ts
+++ b/src/utils/pathUtil.ts
@@ -4,14 +4,6 @@ import * as path from 'path';
 export class PathUtil {
 	public static pathSepRegex = /(?:\\|\/)+/;
 
-	// public static GetWorkspace(): vscode.WorkspaceFolder | undefined {
-	// 	return vscode.workspace.workspaceFolders?.[0];
-	// }
-
-	// public static GetWorkspacePath(): string | undefined {
-	// 	return PathUtil.GetWorkspace()?.uri.fsPath;
-	// }
-
 	public static GetActiveFolderPath() {
 		const path = vscode.window.activeTextEditor?.document.uri.fsPath ?? '';
 		return PathUtil.GetParentDir(path);
@@ -31,11 +23,6 @@ export class PathUtil {
 		return result ?? '';
 	}
 
-	// public static PathExistsRelativeToWorkspace(file: string) {
-	// 	const fullPath = path.join(PathUtil.GetWorkspacePath() ?? '', file);
-	// 	return fs.existsSync(fullPath);
-	// }
-
 	public static GetFirstNonEmptyElem(paths: string[]) {
 		for (const i in paths) {
 			if (paths[i].length) {
@@ -47,9 +34,4 @@ export class PathUtil {
 	public static GetFileName(file: string) {
 		return path.basename(file);
 	}
-
-	// public static IsLooseFilePath(file: string) {
-	// 	const absPath = path.join(PathUtil.GetWorkspacePath() ?? '', file);
-	// 	return !fs.existsSync(absPath);
-	// }
 }

--- a/src/utils/settingsUtil.ts
+++ b/src/utils/settingsUtil.ts
@@ -144,7 +144,7 @@ export class SettingUtil {
 
 		vscode.window
 			.showQuickPick(workspacePaths, {
-				placeHolder: 'Choose Default Workspace for the Server',
+				placeHolder: 'Choose Default Workspace for Live Server',
 			})
 			.then((workspacePath) => {
 				if (!workspacePath) {


### PR DESCRIPTION
Allows the user to select the default workspace for the server root.
![image](https://user-images.githubusercontent.com/31675041/123710899-bf070100-d82c-11eb-922d-bd962db93784.png)

Reload is required for the workspace to be used in order to avoid confusion with address changes when the root changes.
![image](https://user-images.githubusercontent.com/31675041/123710973-dfcf5680-d82c-11eb-9416-b9a6c21f09e0.png)

The server workspace is configurable in settings.
![image](https://user-images.githubusercontent.com/31675041/123711056-0bead780-d82d-11eb-91ed-6e1f1064bf9a.png)

When nothing is set and multiple workspaces are possible, a notification will open to warn the user.
![image](https://user-images.githubusercontent.com/31675041/123711482-ca0e6100-d82d-11eb-82cb-b7d309c352a2.png)

When the user uses an invalid path, they will be notified upon opening the preview.
![image](https://user-images.githubusercontent.com/31675041/123712349-65540600-d82f-11eb-8559-356541e8055b.png)

Closes https://github.com/microsoft/vscode/issues/126622