### PR TITLE
Allow for Workspace Server Root Change w/o Reload

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,7 +196,8 @@
 		"webpack-dev": "webpack --mode development --watch",
 		"build-preview": "npx webpack-cli --mode development",
 		"compile": "node codicon_copy.js && tsc -p ./",
-		"watch": "node codicon_copy.js && tsc -watch -p ./"
+		"watch": "node codicon_copy.js && tsc -watch -p ./",
+		"format": "prettier ./src/**/*.ts --write"
 	},
 	"devDependencies": {
 		"@types/node": "^12.12.0",

--- a/src/editorPreview/browserPreview.ts
+++ b/src/editorPreview/browserPreview.ts
@@ -1,5 +1,10 @@
 import * as vscode from 'vscode';
-import { CONFIG_MULTIROOT, HOST, INIT_PANEL_TITLE, OPEN_EXTERNALLY } from '../utils/constants';
+import {
+	CONFIG_MULTIROOT,
+	HOST,
+	INIT_PANEL_TITLE,
+	OPEN_EXTERNALLY,
+} from '../utils/constants';
 import { Disposable } from '../utils/dispose';
 import { isFileInjectable } from '../utils/utils';
 import { PathUtil } from '../utils/pathUtil';
@@ -44,7 +49,7 @@ export class BrowserPreview extends Disposable {
 		initialFile: string,
 		private readonly _reporter: TelemetryReporter,
 		private readonly _workspaceManager: WorkspaceManager,
-		private readonly _endpointManager: EndpointManager,
+		private readonly _endpointManager: EndpointManager
 	) {
 		super();
 
@@ -388,11 +393,11 @@ export class BrowserPreview extends Disposable {
 		}
 	}
 
-
-	
-	private refreshTarget(oldPath:string, newPath: string) {
+	private refreshTarget(oldPath: string, newPath: string) {
 		const prevAddr = this.currentAddress;
-		const newAddr = this._endpointManager.refreshPath(prevAddr,oldPath,newPath).replace(/\\/g, '/');
+		const newAddr = this._endpointManager
+			.refreshPath(prevAddr, oldPath, newPath)
+			.replace(/\\/g, '/');
 
 		if (prevAddr != newAddr) {
 			this.goToFile(newAddr);

--- a/src/editorPreview/browserPreview.ts
+++ b/src/editorPreview/browserPreview.ts
@@ -1,17 +1,20 @@
 import * as vscode from 'vscode';
-import { HOST, INIT_PANEL_TITLE, OPEN_EXTERNALLY } from '../utils/constants';
+import { CONFIG_MULTIROOT, HOST, INIT_PANEL_TITLE, OPEN_EXTERNALLY } from '../utils/constants';
 import { Disposable } from '../utils/dispose';
 import { isFileInjectable } from '../utils/utils';
 import { PathUtil } from '../utils/pathUtil';
 import { PageHistory, NavEditCommands } from './pageHistoryTracker';
 import TelemetryReporter from 'vscode-extension-telemetry';
 import { WorkspaceManager } from '../multiRootManagers/workspaceManager';
+import { EndpointManager } from '../multiRootManagers/endpointManager';
+import { SETTINGS_SECTION_ID, SettingUtil } from '../utils/settingsUtil';
 
 export class BrowserPreview extends Disposable {
 	public static readonly viewType = 'browserPreview';
 	private readonly _pageHistory: PageHistory;
 
 	private currentAddress: string;
+	// private _currentWorkspacePath: string; // used for resolving old addresses
 	private readonly _onDisposeEmitter = this._register(
 		new vscode.EventEmitter<void>()
 	);
@@ -40,7 +43,8 @@ export class BrowserPreview extends Disposable {
 		private _wsPort: number,
 		initialFile: string,
 		private readonly _reporter: TelemetryReporter,
-		private readonly _workspaceManager: WorkspaceManager
+		private readonly _workspaceManager: WorkspaceManager,
+		private readonly _endpointManager: EndpointManager,
 	) {
 		super();
 
@@ -56,7 +60,14 @@ export class BrowserPreview extends Disposable {
 				'preview-dark.svg'
 			),
 		};
+		// this._currentWorkspacePath = _workspaceManager.workspacePath;
 		this._pageHistory = this._register(new PageHistory());
+
+		this._register(
+			this._workspaceManager.onWorkspaceChange((e) => {
+				this.refreshTarget(e.oldPath, e.newPath);
+			})
+		);
 
 		this.updateForwardBackArrows();
 
@@ -374,6 +385,18 @@ export class BrowserPreview extends Disposable {
 			}
 		} else {
 			this._panel.title = title;
+		}
+	}
+
+
+	
+	private refreshTarget(oldPath:string, newPath: string) {
+		const prevAddr = this.currentAddress;
+		const newAddr = this._endpointManager.refreshPath(prevAddr,oldPath,newPath).replace(/\\/g, '/');
+
+		if (prevAddr != newAddr) {
+			this.goToFile(newAddr);
+			this.handleNewPageLoad(newAddr);
 		}
 	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,7 +47,7 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand(
 			`${SETTINGS_SECTION_ID}.config.selectWorkspace`,
 			() => {
-				SettingUtil.UpdateWorkspacePath();
+				SettingUtil.UpdateWorkspacePath(manager);
 			}
 		)
 	);

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -53,7 +53,7 @@ export class Manager extends Disposable {
 	public get workspace(): vscode.WorkspaceFolder | undefined {
 		return this._workspaceManager.workspace;
 	}
-	
+
 	public get workspacePath(): string | undefined {
 		return this._workspaceManager.workspacePath;
 	}
@@ -290,7 +290,6 @@ export class Manager extends Disposable {
 		this._notifiedAboutLooseFiles = true;
 	}
 
-	
 	private startEmbeddedPreview(panel: vscode.WebviewPanel, file: string) {
 		if (this._currentTimeout) {
 			clearTimeout(this._currentTimeout);

--- a/src/multiRootManagers/endpointManager.ts
+++ b/src/multiRootManagers/endpointManager.ts
@@ -35,11 +35,14 @@ export class EndpointManager extends Disposable {
 		return parentWithIndex.substr(parentWithIndex.indexOf('_') + 1);
 	}
 
-	public refreshPath(targetPath: string, oldWorkspacePath: string, newWorkspacePath: string) {
-		
+	public refreshPath(
+		targetPath: string,
+		oldWorkspacePath: string,
+		newWorkspacePath: string
+	) {
 		let decodedPath = this.decodeLooseFileEndpoint(targetPath);
 		if (!decodedPath) {
-			decodedPath = path.join(oldWorkspacePath,targetPath);
+			decodedPath = path.join(oldWorkspacePath, targetPath);
 		}
 		if (decodedPath.startsWith(newWorkspacePath)) {
 			return decodedPath.substr(newWorkspacePath.length);

--- a/src/multiRootManagers/endpointManager.ts
+++ b/src/multiRootManagers/endpointManager.ts
@@ -1,6 +1,7 @@
 import { Disposable } from '../utils/dispose';
 import * as path from 'path';
 import { PathUtil } from '../utils/pathUtil';
+import * as vscode from 'vscode';
 
 export class EndpointManager extends Disposable {
 	// manages encoding and decoding endpoints
@@ -32,6 +33,19 @@ export class EndpointManager extends Disposable {
 		const endpoint = PathUtil.GetFurthestParentDir(urlPath);
 		const parentWithIndex = endpoint.substr(0, endpoint.lastIndexOf('_'));
 		return parentWithIndex.substr(parentWithIndex.indexOf('_') + 1);
+	}
+
+	public refreshPath(targetPath: string, oldWorkspacePath: string, newWorkspacePath: string) {
+		
+		let decodedPath = this.decodeLooseFileEndpoint(targetPath);
+		if (!decodedPath) {
+			decodedPath = path.join(oldWorkspacePath,targetPath);
+		}
+		if (decodedPath.startsWith(newWorkspacePath)) {
+			return decodedPath.substr(newWorkspacePath.length);
+		} else {
+			return this.encodeLooseFileEndpoint(decodedPath);
+		}
 	}
 
 	public decodeLooseFileEndpoint(urlPath: string): string | undefined {

--- a/src/multiRootManagers/workspaceManager.ts
+++ b/src/multiRootManagers/workspaceManager.ts
@@ -1,24 +1,67 @@
 import { Disposable } from '../utils/dispose';
-import { SETTINGS_SECTION_ID, SettingUtil } from '../utils/settingsUtil';
+import { Settings, SETTINGS_SECTION_ID, SettingUtil } from '../utils/settingsUtil';
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
-import { CONFIG_MULTIROOT } from '../utils/constants';
+import { CONFIG_MULTIROOT, DONT_SHOW_AGAIN } from '../utils/constants';
+
+
+export interface workspaceChangeMsg {
+	oldPath: string;
+	newPath: string;
+}
 
 export class WorkspaceManager extends Disposable {
-	private readonly _workspace: vscode.WorkspaceFolder | undefined;
-	public settingsWorkspace = '';
+	private _notifiedAboutMultiRoot = false;
+	private _workspace: vscode.WorkspaceFolder | undefined;
+	private _settingsWorkspace = '';
 	public invalidPath = false;
+
+	private readonly _onWorkspaceChange = this._register(
+		new vscode.EventEmitter<workspaceChangeMsg>()
+	);
+	public readonly onWorkspaceChange = this._onWorkspaceChange.event;
+
 	constructor(private readonly _extensionUri: vscode.Uri) {
 		super();
-		if (this.numPaths > 1) {
-			this.settingsWorkspace = SettingUtil.GetConfig(
-				this._extensionUri
-			).serverWorkspace;
-			this._workspace = this.getWorkspaceFromPath(this.settingsWorkspace);
+	}
+
+	public updateConfigurations() {
+		const newPath = SettingUtil.GetConfig(this._extensionUri).serverWorkspace;
+		if (this.isAWorkspacePath(newPath)) {
+			const oldWorkspacePath = this.workspacePath;
+			if (this.numPaths > 1) {
+				this._settingsWorkspace = SettingUtil.GetConfig(
+					this._extensionUri
+				).serverWorkspace;
+				this._workspace = this.getWorkspaceFromPath(this._settingsWorkspace);
+			} else {
+				this._workspace = this.firstListedWorkspace;
+			}
+			this._onWorkspaceChange.fire({ oldPath: oldWorkspacePath ?? '', newPath: this.workspacePath ?? '' });
 		} else {
+			this.warnAboutBadPath(newPath);
+			this._settingsWorkspace = newPath;
 			this._workspace = this.firstListedWorkspace;
 		}
+	}
+
+	private warnAboutBadPath(badPath: string) {
+		const optMsg = this.workspace
+			? `Using ${this.workspace?.name} instead.`
+			: ``;
+		vscode.window
+			.showWarningMessage(
+				`Cannot use workspace at ${badPath} for server. ${optMsg}`,
+				CONFIG_MULTIROOT
+			)
+			.then((selection: vscode.MessageItem | undefined) => {
+				if (selection == CONFIG_MULTIROOT) {
+					vscode.commands.executeCommand(
+						`${SETTINGS_SECTION_ID}.config.selectWorkspace`
+					);
+				}
+			});
 	}
 
 	public get workspace(): vscode.WorkspaceFolder | undefined {
@@ -36,7 +79,9 @@ export class WorkspaceManager extends Disposable {
 	public get numPaths(): number {
 		return vscode.workspace.workspaceFolders?.length ?? 0;
 	}
-
+	public canGetPath(path: string) {
+		return this.workspacePath ? path.startsWith(this.workspacePath) : false;
+	}
 	public pathExistsRelativeToWorkspace(file: string) {
 		const fullPath = path.join(this.workspacePath ?? '', file);
 		return fs.existsSync(fullPath);
@@ -48,28 +93,76 @@ export class WorkspaceManager extends Disposable {
 	}
 
 	public hasNullPathSetting() {
-		return this.settingsWorkspace == '';
+		return this._settingsWorkspace == '';
+	}
+
+	public isAWorkspacePath(path: string) {
+		const workspacePaths = vscode.workspace.workspaceFolders?.map(
+			(e) => e.uri.fsPath
+		);
+
+		return workspacePaths?.includes(path);
 	}
 	private get firstListedWorkspace() {
 		return vscode.workspace.workspaceFolders?.[0];
 	}
 
-	private getWorkspaceFromPath(workspaceName: string) {
+	private getWorkspaceFromPath(workspacePath: string) {
 		const workspaceFolders = vscode.workspace.workspaceFolders;
 		if (!workspaceFolders || workspaceFolders.length == 0) {
 			return undefined;
-		} else if (workspaceName == '') {
+		} else if (workspacePath == '') {
+			if (this.numPaths > 1) {
+				this.notifyMultiRootOpen();
+			}
 			return this.firstListedWorkspace;
 		}
 
 		if (workspaceFolders) {
 			for (let i = 0; i < workspaceFolders.length; i++) {
-				if (workspaceFolders[i].uri.fsPath == workspaceName) {
+				if (workspaceFolders[i].uri.fsPath == workspacePath) {
 					return workspaceFolders[i];
 				}
 			}
 		}
-		this.invalidPath = true;
+
 		return this.firstListedWorkspace;
+	}
+
+	private notifyMultiRootOpen() {
+		if (
+			!this._notifiedAboutMultiRoot &&
+			SettingUtil.GetConfig(this._extensionUri).showWarningOnMultiRootOpen
+		) {
+			vscode.window
+				.showWarningMessage(
+					`There is no set default server workspace to use in your multi-root workspace, so the first workspace (${this.workspacePathname}) will be used.`,
+					DONT_SHOW_AGAIN,
+					CONFIG_MULTIROOT
+				)
+				.then((selection: vscode.MessageItem | undefined) => {
+					if (selection == DONT_SHOW_AGAIN) {
+						SettingUtil.UpdateSettings(
+							Settings.showWarningOnMultiRootOpen,
+							false
+						);
+					} else if (selection == CONFIG_MULTIROOT) {
+						vscode.commands.executeCommand(
+							`${SETTINGS_SECTION_ID}.config.selectWorkspace`
+						);
+					}
+				});
+		}
+		this._notifiedAboutMultiRoot = true;
+	}
+
+	public getFileRelativeToWorkspace(path: string): string {
+		const workspaceFolder = this.workspacePath;
+
+		if (workspaceFolder && path.startsWith(workspaceFolder)) {
+			return path.substr(workspaceFolder.length).replace(/\\/gi, '/');
+		} else {
+			return '';
+		}
 	}
 }

--- a/src/multiRootManagers/workspaceManager.ts
+++ b/src/multiRootManagers/workspaceManager.ts
@@ -27,10 +27,16 @@ export class WorkspaceManager extends Disposable {
 
 	constructor(private readonly _extensionUri: vscode.Uri) {
 		super();
+		this.updateConfigurations();
 	}
 
 	public updateConfigurations() {
 		const newPath = SettingUtil.GetConfig(this._extensionUri).serverWorkspace;
+		if (this.numPaths <= 1) {
+			this._settingsWorkspace = newPath;
+			this._workspace = this.firstListedWorkspace;
+			return;
+		}
 		if (this.isAWorkspacePath(newPath)) {
 			const oldWorkspacePath = this.workspacePath;
 			if (this.numPaths > 1) {

--- a/src/multiRootManagers/workspaceManager.ts
+++ b/src/multiRootManagers/workspaceManager.ts
@@ -1,10 +1,13 @@
 import { Disposable } from '../utils/dispose';
-import { Settings, SETTINGS_SECTION_ID, SettingUtil } from '../utils/settingsUtil';
+import {
+	Settings,
+	SETTINGS_SECTION_ID,
+	SettingUtil,
+} from '../utils/settingsUtil';
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 import { CONFIG_MULTIROOT, DONT_SHOW_AGAIN } from '../utils/constants';
-
 
 export interface workspaceChangeMsg {
 	oldPath: string;
@@ -38,7 +41,10 @@ export class WorkspaceManager extends Disposable {
 			} else {
 				this._workspace = this.firstListedWorkspace;
 			}
-			this._onWorkspaceChange.fire({ oldPath: oldWorkspacePath ?? '', newPath: this.workspacePath ?? '' });
+			this._onWorkspaceChange.fire({
+				oldPath: oldWorkspacePath ?? '',
+				newPath: this.workspacePath ?? '',
+			});
 		} else {
 			this.warnAboutBadPath(newPath);
 			this._settingsWorkspace = newPath;

--- a/src/server/serverManager.ts
+++ b/src/server/serverManager.ts
@@ -10,7 +10,6 @@ import {
 } from '../utils/settingsUtil';
 import { DONT_SHOW_AGAIN } from '../utils/constants';
 import { serverMsg } from '../manager';
-import { PathUtil } from '../utils/pathUtil';
 import TelemetryReporter from 'vscode-extension-telemetry';
 import { EndpointManager } from '../multiRootManagers/endpointManager';
 import { WorkspaceManager } from '../multiRootManagers/workspaceManager';
@@ -25,21 +24,23 @@ export class Server extends Disposable {
 	private readonly _wsServer: WSServer;
 	private readonly _statusBar: StatusBarNotifier;
 	private _isServerOn = false;
-	private _workspacePath: string | undefined;
+
+	private get _workspacePath() {
+		return this._workspaceManager.workspacePath;
+	}
 
 	constructor(
 		private readonly _extensionUri: vscode.Uri,
 		endpointManager: EndpointManager,
 		reporter: TelemetryReporter,
-		workspaceManager: WorkspaceManager
+		private readonly _workspaceManager: WorkspaceManager
 	) {
 		super();
 		this._httpServer = this._register(
-			new HttpServer(_extensionUri, reporter, endpointManager)
+			new HttpServer(_extensionUri, reporter, endpointManager, _workspaceManager)
 		);
-		this._wsServer = this._register(new WSServer(reporter, endpointManager));
+		this._wsServer = this._register(new WSServer(reporter, endpointManager, _workspaceManager));
 		this._statusBar = this._register(new StatusBarNotifier(_extensionUri));
-		this._workspacePath = workspaceManager.workspacePath;
 
 		this._register(
 			vscode.workspace.onDidChangeTextDocument((e) => {
@@ -144,19 +145,19 @@ export class Server extends Disposable {
 		return this._isServerOn;
 	}
 
-	public canGetPath(path: string) {
-		return this._workspacePath ? path.startsWith(this._workspacePath) : false;
-	}
+	// public canGetPath(path: string) {
+	// 	return this._workspaceManager.canGetPath(path);
+	// }
 
-	public getFileRelativeToWorkspace(path: string): string {
-		const workspaceFolder = this._workspacePath;
+	// public getFileRelativeToWorkspace(path: string): string {
+	// 	const workspaceFolder = this._workspacePath;
 
-		if (workspaceFolder && path.startsWith(workspaceFolder)) {
-			return path.substr(workspaceFolder.length).replace(/\\/gi, '/');
-		} else {
-			return '';
-		}
-	}
+	// 	if (workspaceFolder && path.startsWith(workspaceFolder)) {
+	// 		return path.substr(workspaceFolder.length).replace(/\\/gi, '/');
+	// 	} else {
+	// 		return '';
+	// 	}
+	// }
 
 	public updateConfigurations() {
 		this._statusBar.updateConfigurations();
@@ -207,14 +208,14 @@ export class Server extends Disposable {
 			// initialize websockets to use port after http server port
 			this._httpServer.setInjectorWSPort(port + 1);
 
-			this._httpServer.start(port, this._workspacePath ?? '');
+			this._httpServer.start(port);
 			return true;
 		}
 		return false;
 	}
 
 	private httpServerConnected() {
-		this._wsServer.start(this._httpServer.port + 1, this._workspacePath ?? '');
+		this._wsServer.start(this._httpServer.port + 1);
 	}
 
 	private wsServerConnected() {

--- a/src/server/serverManager.ts
+++ b/src/server/serverManager.ts
@@ -37,9 +37,16 @@ export class Server extends Disposable {
 	) {
 		super();
 		this._httpServer = this._register(
-			new HttpServer(_extensionUri, reporter, endpointManager, _workspaceManager)
+			new HttpServer(
+				_extensionUri,
+				reporter,
+				endpointManager,
+				_workspaceManager
+			)
 		);
-		this._wsServer = this._register(new WSServer(reporter, endpointManager, _workspaceManager));
+		this._wsServer = this._register(
+			new WSServer(reporter, endpointManager, _workspaceManager)
+		);
 		this._statusBar = this._register(new StatusBarNotifier(_extensionUri));
 
 		this._register(

--- a/src/server/wsServer.ts
+++ b/src/server/wsServer.ts
@@ -7,15 +7,21 @@ import { Disposable } from '../utils/dispose';
 import { isFileInjectable } from '../utils/utils';
 import TelemetryReporter from 'vscode-extension-telemetry';
 import { EndpointManager } from '../multiRootManagers/endpointManager';
+import { WorkspaceManager } from '../multiRootManagers/workspaceManager';
 
 export class WSServer extends Disposable {
 	private _wss: WebSocket.Server | undefined;
 	private _ws_port = 0;
 	constructor(
 		private readonly _reporter: TelemetryReporter,
-		private readonly _endpointManager: EndpointManager
+		private readonly _endpointManager: EndpointManager,
+		private readonly _workspaceManager: WorkspaceManager
 	) {
 		super();
+	}
+
+	private get _basePath() {
+		return this._workspaceManager.workspacePath;
 	}
 
 	public get ws_port() {
@@ -31,9 +37,9 @@ export class WSServer extends Disposable {
 	);
 	public readonly onConnected = this._onConnected.event;
 
-	public start(ws_port: number, basePath: string) {
+	public start(ws_port: number) {
 		this._ws_port = ws_port;
-		this.startWSServer(basePath);
+		this.startWSServer(this._basePath ?? '');
 	}
 
 	public close() {

--- a/src/utils/settingsUtil.ts
+++ b/src/utils/settingsUtil.ts
@@ -99,15 +99,11 @@ export class SettingUtil {
 	public static UpdateSettings<T>(
 		settingSuffix: string,
 		value: T,
-		isGlobal = true,
-		showGotoSettings = true
+		isGlobal = true
 	): void {
 		vscode.workspace
 			.getConfiguration(SETTINGS_SECTION_ID)
 			.update(settingSuffix, value, isGlobal);
-		if (showGotoSettings) {
-			SettingUtil.SettingsSavedMessage();
-		}
 	}
 
 	public static SettingsSavedMessage(): void {

--- a/src/utils/settingsUtil.ts
+++ b/src/utils/settingsUtil.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { Manager } from '../manager';
 import { GO_TO_SETTINGS, RELOAD_WINDOW } from './constants';
 
 export interface LiveServerConfigItem {
@@ -125,12 +126,12 @@ export class SettingUtil {
 			});
 	}
 
-	public static UpdateWorkspacePath() {
+	public static UpdateWorkspacePath(manager: Manager) {
 		// choose workspace path:
 		const workspacePaths = vscode.workspace.workspaceFolders?.map(
 			(e) => e.uri.fsPath
 		);
-		let workspacePath: string;
+		// let workspacePath: string;
 
 		if (!workspacePaths) {
 			vscode.window.showErrorMessage('No workspaces open.');
@@ -154,20 +155,10 @@ export class SettingUtil {
 				SettingUtil.UpdateSettings(
 					Settings.serverWorkspace,
 					workspacePath,
-					false,
 					false
 				);
-
-				vscode.window
-					.showInformationMessage(
-						`Reload window to use new workspace: ${workspacePath}`,
-						RELOAD_WINDOW
-					)
-					.then((selection: vscode.MessageItem | undefined) => {
-						if (selection === RELOAD_WINDOW) {
-							vscode.commands.executeCommand('workbench.action.reloadWindow');
-						}
-					});
+				// manager.refreshEmbeddedTarget(workspacePath);
+				// manager.encodeEndpoint(workspacePath);
 			});
 	}
 }


### PR DESCRIPTION
Can now change server root without reloading. The embedded browser will also auto-redirect the preview to the new endpoint if necessary (and vice versa)

[![Image from Gyazo](https://i.gyazo.com/a4d50b6b6e5df774bc1ce555a0f2bb49.gif)](https://gyazo.com/a4d50b6b6e5df774bc1ce555a0f2bb49)

Also removed post-update settings info message.

Closes https://github.com/microsoft/vscode/issues/127465
Closes https://github.com/microsoft/vscode/issues/127519