### PR TITLE
UX Improvements (Misc Testplan Feedback)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 ⚠️ WARNING: this extension is still under initial development! Use at your own risk. ⚠️
 
-An extension that hosts a local server for you to preview your web projects on!
+An extension that hosts a local server for you to preview your web projects on! 
+
+Note: this extension is intended for projects where a server is not already created (e.g. not for apps using React, Angular, etc.). To work with these, feel free to run the `Simple Browser: Show` command that is already built-in with VS Code.
 
 ## Table of Contents
 - [Features](#features)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ No workspace? No problem! For a quick preview of your file, the server can also 
 
 Notes about workspace-less extension use:
 - Linked files for these pages may not be correct if they are relative to a specific root (e.g. a project root). 
-- Tasks do not work outside of a workspace, so a server will just launch in the background upon external preview when outside of a workspace. You can use the `Live Preview: Force Stop Server` command to kill the server in this case.
+- Tasks do not work outside of a workspace, so a server will just launch in the background upon external preview when outside of a workspace. You can use the `Live Preview: Stop Server` command to kill the server in this case.
 
 ### Multi-root Support
 When using a multi-root workspace, use `Live Preview: Select Default Workspace for Server` to select a default workspace for the server root. The selection will be saved in your workspace setting. Alternatively, you can also directly assign a path to the `LivePreview.serverWorkspace` setting.

--- a/media/vscode.css
+++ b/media/vscode.css
@@ -142,8 +142,8 @@ textarea::placeholder {
     bottom:-4px;
     left:0px; 
     padding:3px 5px;
-    background-color:rgb(66, 66, 66);
-    color:#fff;
+    background-color:var(--vscode-input-background);
+    color:var(--vscode-input-foreground);
     font-size:9px;
     box-shadow: 1px -1px 5px rgb(129, 129, 129);
     border-radius:1px;

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
 					"type": "string",
 					"scope": "resource",
 					"default": "",
-					"description": "For multi-root workspaces: which workspace path should be used as the server root. Leave blank to use first workspace. Reload window to use changed setting."
+					"description": "For multi-root workspaces: which workspace path should be used as the server root. Leave blank to use first workspace."
 				},
 				"LivePreview.showWarningOnMultiRootOpen": {
 					"type": "boolean",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
 			},
 			{
 				"command": "LivePreview.end",
-				"title": "Live Preview: Force Stop Server"
+				"title": "Live Preview: Stop Server"
 			}
 		],
 		"menus": {
@@ -87,24 +87,52 @@
 				{
 					"command": "LivePreview.start.preview.atFile",
 					"when": "resourceLangId == html",
-					"group": "navigation"
+					"group": "1_livepreview"
+				}
+			],
+			"editor/context": [
+				{
+					"command": "LivePreview.start.preview.atFile",
+					"when": "resourceLangId == html",
+					"group": "1_livepreview"
 				}
 			],
 			"commandPalette": [
 				{
 					"command": "LivePreview.start.preview.atFile",
-					"when": "editorLangId == html && !notebookEditorFocused",
-					"group": "navigation"
+					"when": "false"
+				},
+				{
+					"command": "LivePreview.start.preview.atIndex",
+					"when": "false"
+				},
+				{
+					"command": "LivePreview.start.externalPreview.atIndex",
+					"when": "false"
+				},
+				{
+					"command": "LivePreview.start.internalPreview.atIndex",
+					"when": "false"
+				},
+				{
+					"command": "LivePreview.config.selectWorkspace",
+					"when": "workspaceFolderCount > 1",
+					"group": "1_livepreview"
 				},
 				{
 					"command": "LivePreview.start.internalPreview.atFile",
 					"when": "editorLangId == html && !notebookEditorFocused",
-					"group": "navigation"
+					"group": "1_livepreview"
 				},
 				{
 					"command": "LivePreview.start.externalPreview.atFile",
 					"when": "editorLangId == html && !notebookEditorFocused",
-					"group": "navigation"
+					"group":"1_livepreview"
+				},
+				{
+					"command": "LivePreview.end",
+					"when": "LivePreviewServerOn",
+					"group": "1_livepreview"
 				}
 			]
 		},
@@ -130,7 +158,7 @@
 					"default": true,
 					"description": "Whether to show the current hosting port when server is open on the status bar."
 				},
-				"LivePreview.showServerStatusPopUps": {
+				"LivePreview.showServerStatusNotifications": {
 					"type": "boolean",
 					"default": false,
 					"description": "Whether or not to show information messages on server on/off status change."
@@ -155,7 +183,7 @@
 				"LivePreview.browserPreviewLaunchServerLogging": {
 					"type": "boolean",
 					"default": true,
-					"description": "Upon running `Show Preview in External Browser`, whether the auto-general terminal has logging."
+					"description": "Whether the auto-generated task terminal has logging after running \"Show Preview in External Browser\"."
 				},
 				"LivePreview.notifyOnOpenLooseFile": {
 					"type": "boolean",

--- a/src/server/serverManager.ts
+++ b/src/server/serverManager.ts
@@ -120,6 +120,7 @@ export class Server extends Disposable {
 				this.httpServerConnected();
 			})
 		);
+		vscode.commands.executeCommand('setContext', 'LivePreviewServerOn', false);
 	}
 
 	public get port() {
@@ -198,6 +199,7 @@ export class Server extends Disposable {
 		this._statusBar.ServerOff();
 
 		this.showServerStatusMessage('Server Closed');
+		vscode.commands.executeCommand('setContext', 'LivePreviewServerOn', false);
 	}
 
 	public openServer(port: number): boolean {
@@ -223,15 +225,21 @@ export class Server extends Disposable {
 			`Server Opened on Port ${this._httpServer.port}`
 		);
 		this._connectionManager.connected({ port: this._httpServer.port });
+		vscode.commands.executeCommand('setContext', 'LivePreviewServerOn', true);
 	}
 
 	private showServerStatusMessage(messsage: string) {
-		if (SettingUtil.GetConfig(this._extensionUri).showServerStatusPopUps) {
+		if (
+			SettingUtil.GetConfig(this._extensionUri).showServerStatusNotifications
+		) {
 			vscode.window
 				.showInformationMessage(messsage, DONT_SHOW_AGAIN)
 				.then((selection: vscode.MessageItem | undefined) => {
 					if (selection == DONT_SHOW_AGAIN) {
-						SettingUtil.UpdateSettings(Settings.showServerStatusPopUps, false);
+						SettingUtil.UpdateSettings(
+							Settings.showServerStatusNotifications,
+							false
+						);
 					}
 				});
 		}

--- a/src/server/serverManager.ts
+++ b/src/server/serverManager.ts
@@ -143,40 +143,14 @@ export class Server extends Disposable {
 		return this._isServerOn;
 	}
 
-	// public canGetPath(path: string) {
-	// 	return this._workspaceManager.canGetPath(path);
-	// }
-
-	// public getFileRelativeToWorkspace(path: string): string {
-	// 	const workspaceFolder = this._workspacePath;
-
-	// 	if (workspaceFolder && path.startsWith(workspaceFolder)) {
-	// 		return path.substr(workspaceFolder.length).replace(/\\/gi, '/');
-	// 	} else {
-	// 		return '';
-	// 	}
-	// }
-
 	public updateConfigurations() {
 		this._statusBar.updateConfigurations();
 	}
-
-	// private readonly _onPortChangeEmitter = this._register(
-	// 	new vscode.EventEmitter<PortInfo>()
-	// );
-
-	// public readonly onPortChange = this._onPortChangeEmitter.event;
 
 	private readonly _onNewReqProcessed = this._register(
 		new vscode.EventEmitter<serverMsg>()
 	);
 	public readonly onNewReqProcessed = this._onNewReqProcessed.event;
-
-	// private readonly _onFullyConnected = this._register(
-	// 	new vscode.EventEmitter<{ port: number }>()
-	// );
-
-	// public readonly onFullyConnected = this._onFullyConnected.event;
 
 	private get _reloadOnAnyChange() {
 		return (

--- a/src/server/serverUtils/statusBarNotifier.ts
+++ b/src/server/serverUtils/statusBarNotifier.ts
@@ -26,7 +26,12 @@ export class StatusBarNotifier extends Disposable {
 		}
 
 		this._statusBar.text = `$(radio-tower) Port: ${port}`;
-		this._statusBar.tooltip = `Live Sever running on port ${port}`;
+		this._statusBar.tooltip = `Live Preview running on port ${port}`;
+		this._statusBar.command = {
+			title: 'Open Command Palette',
+			command: 'workbench.action.quickOpen',
+			arguments: ['>Live Preview: '],
+		};
 	}
 
 	public ServerOff() {

--- a/src/task/serverTaskTerminal.ts
+++ b/src/task/serverTaskTerminal.ts
@@ -109,7 +109,7 @@ export class ServerTaskTerminal
 		);
 		this.writeEmitter.fire(
 			this.colorTerminalString(
-				`Run 'Force Stop Live Preview Server' in the command palette to force close the server and close any previews.\r\n\r\n`,
+				`Run 'Stop Live Preview Server' in the command palette to close the server and close any previews.\r\n\r\n`,
 				TerminalColor.yellow
 			)
 		);

--- a/src/utils/settingsUtil.ts
+++ b/src/utils/settingsUtil.ts
@@ -5,7 +5,7 @@ import { GO_TO_SETTINGS, RELOAD_WINDOW } from './constants';
 export interface LiveServerConfigItem {
 	portNumber: number;
 	showStatusBarItem: boolean;
-	showServerStatusPopUps: boolean;
+	showServerStatusNotifications: boolean;
 	autoRefreshPreview: AutoRefreshPreview;
 	browserPreviewLaunchServerLogging: boolean;
 	openPreviewTarget: OpenPreviewTarget;
@@ -31,7 +31,7 @@ export const SETTINGS_SECTION_ID = 'LivePreview';
 export const Settings: any = {
 	portNumber: 'portNumber',
 	showStatusBarItem: 'showStatusBarItem',
-	showServerStatusPopUps: 'showServerStatusPopUps',
+	showServerStatusNotifications: 'showServerStatusNotifications',
 	autoRefreshPreview: 'autoRefreshPreview',
 	browserPreviewLaunchServerLogging: 'browserPreviewLaunchServerLogging',
 	openPreviewTarget: 'openPreviewTarget',
@@ -54,8 +54,8 @@ export class SettingUtil {
 		return {
 			portNumber: config.get<number>(Settings.portNumber, 3000),
 			showStatusBarItem: config.get<boolean>(Settings.showStatusBarItem, true),
-			showServerStatusPopUps: config.get<boolean>(
-				Settings.showServerStatusPopUps,
+			showServerStatusNotifications: config.get<boolean>(
+				Settings.showServerStatusNotifications,
 				false
 			),
 			autoRefreshPreview: config.get<AutoRefreshPreview>(


### PR DESCRIPTION
Addressing a few misc suggestions from testplan:

Editor context menu to open preview.
Closes https://github.com/microsoft/vscode/issues/127540

`Stop Server` only shows when server is on.
Closes https://github.com/microsoft/vscode/issues/127514

Changed `Force Stop Server` to `Stop Server`.
Closes https://github.com/microsoft/vscode/issues/127512

Replaced mentions of "Pop-ups" with "Notifications"
Closes https://github.com/microsoft/vscode/issues/127474

Show Live Preview commands when clicking on the status bar item.
Closes https://github.com/microsoft/vscode/issues/127472

Hide misc commands from command palette for cleaner look.
Closes https://github.com/microsoft/vscode/issues/127469

Moved context menu position to own section.
Closes https://github.com/microsoft/vscode/issues/127466

Fixed default task terminal logging setting description to make more sense + removing backticks.
Closes https://github.com/microsoft/vscode/issues/127463

Added note in readme to make extension use case clearer.
Closes #31 